### PR TITLE
feat: use our next site for algolia index

### DIFF
--- a/src/components/site-search/site-search.fe.ts
+++ b/src/components/site-search/site-search.fe.ts
@@ -35,7 +35,7 @@ requestAnimationFrame(() => {
 
 		let search = utils.createSearch({
 			appId: 'EQEH1X5N4X',
-			indexName: 'astrouxds',
+			indexName: 'astrouxds-next',
 			apiKey: 'a402f3cc6d8965606af2d7235ba75700',
 		})
 


### PR DESCRIPTION
huzzzah, we can now pull in content from next.astrouxds.org instead of the current live site. You can test this works by searching for "design tokens". Those pages only exist on next.

Unfortunately, the results for 'design tokens' are kind of a mess. We'll probably need to tweak the algolia juice somehow. 

Adding to the nice-to-have-list, it would be great if the `indexName` here could be dynamic: on main, just be `astrouxds`, on next, `astrouxds-next` so that we don't have to worry about anything when we deploy