### PR TITLE
refactor: add copyright blockquote from old site

### DIFF
--- a/src/pages/getting-started/index.md
+++ b/src/pages/getting-started/index.md
@@ -61,6 +61,18 @@ When implementing Astro Space UX Design System users should consult with their o
 
 :::
 
+> Copyright © {{ meta.copyright }} Rocket Communications, Inc.
+>
+> The Astro Space UX Design System, which includes user workflows, interfaces, visual components, system functionality, sample code, style guides, best practices guidelines, sample applications, and related sample software, all of which is publicly available at www.astroUXDS.com (collectively referred to herein as the “Software”), is developed and maintained by Rocket Communications, Inc. (“Rocket”) through a contract with the United States government.
+>
+> As a work commissioned by the United States government, the Software is in the public domain within the United States.
+>
+> A non-exclusive, worldwide, a royalty-free license is hereby granted, free of charge, to any person (referred to herein as “Recipient”) obtaining a copy of the Software, or any part thereof, and any associated documentation files, to use the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: (i) any copy of the Software, or part thereof, distributed by Recipient must include the copyright notice noted above, and (ii) Recipient agrees to the following warranty and waiver conditions:
+>
+> THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY OF ANY KIND, EITHER EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR FREEDOM FROM INFRINGEMENT, ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR-FREE, OR ANY WARRANTY THAT DOCUMENTATION, IF PROVIDED, WILL CONFORM TO THE SOFTWARE. THIS AGREEMENT DOES NOT, IN ANY MANNER, CONSTITUTE AN ENDORSEMENT BY THE UNITED STATES GOVERNMENT OR ANY OF ITS CONTRACTORS OF ANY RESULTS, RESULTING DESIGNS, HARDWARE, SOFTWARE PRODUCTS, OR ANY OTHER APPLICATIONS RESULTING FROM USE OF THE SOFTWARE. FURTHER, THE UNITED STATES GOVERNMENT AND ITS CONTRACTORS DISCLAIM ALL WARRANTIES AND LIABILITIES REGARDING THIRD-PARTY SOFTWARE, IF PRESENT, IN THE SOFTWARE, AND DISTRIBUTE IT "AS IS."
+>
+> RECIPIENT AGREES TO WAIVE ANY AND ALL CLAIMS AGAINST THE UNITED STATES GOVERNMENT, ITS CONTRACTORS AND SUBCONTRACTORS, AS WELL AS ANY PRIOR RECIPIENT. IF RECIPIENT'S USE OF THE SOFTWARE RESULTS IN ANY LIABILITIES, DEMANDS, DAMAGES, EXPENSES OR LOSSES ARISING FROM SUCH USE, INCLUDING ANY DAMAGES FROM PRODUCTS BASED ON, OR RESULTING FROM, RECIPIENT'S USE OF THE SOFTWARE, RECIPIENT SHALL INDEMNIFY AND HOLD HARMLESS THE UNITED STATES GOVERNMENT, ITS CONTRACTORS AND SUBCONTRACTORS, AS WELL AS ANY PRIOR RECIPIENT, TO THE EXTENT PERMITTED BY LAW. RECIPIENT'S SOLE REMEDY FOR ANY SUCH MATTER SHALL BE THE IMMEDIATE, UNILATERAL TERMINATION OF THIS AGREEMENT.
+
 ### Offline access
 
 This website and its contents are provided as separate downloadable files for the convenience of developers and designers working in closed environments. Designer and Developer assets are provided as downloads on their respective ‘Getting Started’ sections:


### PR DESCRIPTION
I've added the copyright block quote from the old getting started page to the new site, but the block quotes do not seem to be getting pick up? 

When I preview the getting-started md file in vscode the block quotes are working.