### PR TITLE
feat: add contributions-footer to docs-layout

### DIFF
--- a/src/components/contribution-footer/contribution-footer.astro
+++ b/src/components/contribution-footer/contribution-footer.astro
@@ -1,0 +1,13 @@
+---
+import "./contribution-footer.css"
+---
+
+<footer id="contribution-footer">
+  <h3>Help improve this page</h3>
+  <p>You can help improve this page, with updated information, guidance or fixes for typos and errors.</p>
+  <ul>
+    <!-- TODO - Resolve dynamic linking to edit on github repo -->
+    <li><a href="{{ meta.repo if meta.repo else 'https://github.com/RocketCommunicationsInc/astro' }}/edit/{{ meta.branch if meta.branch else 'main' }}/packages/astro-uxds/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
+    <li><a href="/community/propose-a-change/">How to propose a change</a></li>
+  </ul>
+</footer>

--- a/src/layouts/docs/docs-layout.astro
+++ b/src/layouts/docs/docs-layout.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../default/default-layout-with-grid.astro'
 import SiteNavigation from '../../components/site-navigation/site-navigation.astro'
+import ContributionFooter from '../../components/contribution-footer/contribution-footer.astro'
 import SiteFooter from '../../components/site-footer/site-footer.astro'
 
 import './docs-layout.css'
@@ -26,6 +27,7 @@ const demoCSS = height ? `.storybook-demo{${[
 
 	<main class="p-content" id="content">
 		<slot />
+		<ContributionFooter />
 	</main>
 
 	<SiteFooter slot="foot" />


### PR DESCRIPTION
I've added a contirbutions-footer component and empty css file for now. There is a dynamic link which will need to be handle  somehow not really able to hard code it unless we link somewhere else. It deep links right to the MD file on the github repo to suggest an edit.

Example dynamic link: https://github.com/RocketCommunicationsInc/astro/edit/next/packages/astro-uxds/_content/getting-started/developers.md
