### PR TITLE
refactor: hard code copyright year on getting started page

### DIFF
--- a/src/pages/getting-started/index.md
+++ b/src/pages/getting-started/index.md
@@ -61,7 +61,7 @@ When implementing Astro Space UX Design System users should consult with their o
 
 :::
 
-> Copyright © {{ meta.copyright }} Rocket Communications, Inc.
+> Copyright © 2022 Rocket Communications, Inc.
 >
 > The Astro Space UX Design System, which includes user workflows, interfaces, visual components, system functionality, sample code, style guides, best practices guidelines, sample applications, and related sample software, all of which is publicly available at www.astroUXDS.com (collectively referred to herein as the “Software”), is developed and maintained by Rocket Communications, Inc. (“Rocket”) through a contract with the United States government.
 >


### PR DESCRIPTION
I went ahead and hard coded the copyright year on the getting started page for now.