### PR TITLE
(homepage-redesign): fixed padding and spacing on articles

### DIFF
--- a/src/components/home/articles/home-articles.css
+++ b/src/components/home/articles/home-articles.css
@@ -1,7 +1,7 @@
 :where(.p-articles) {
 	--articles-size: max(1 * var(--article-size) + 0 * var(--article-gap));
 	--article-size: 75--step;
-	--article-gap: 5--step;
+	--article-gap: 15--step;
 
 	display: grid;
 	grid-template-rows: auto auto;
@@ -9,6 +9,7 @@
 	/* layout */
 	flex-flow: column;
 	max-inline-size: 100%;
+	
 
 	@media (width >= 760px) {
 		--articles-size: max(2 * var(--article-size) + 1 * var(--article-gap));
@@ -138,6 +139,8 @@
 		padding-block: 5--step;
 		padding-inline: 5--step;
 		scroll-snap-align: start;
+		padding: 0;
+	
 
 		/* decoration */
 		background-color: var(--BaseHeaderColor);
@@ -165,6 +168,8 @@
 			font-size: 20--rpx;
 			font-weight: 500;
 			line-height: max(24 / 20);
+			padding-left: 22px;
+			padding-right: 26.5px;
 		}
 
 		& p {
@@ -173,7 +178,9 @@
 
 			/* typography */
 			font-size: 14--rpx;
-			line-height: max(20 / 14);
+			line-height: 16.41px;
+			padding-left: 22px;
+			padding-right: 22px;
 		}
 
 		& a {
@@ -193,6 +200,9 @@
 			box-shadow: var(--InteractiveColor) 0 0 0 1px inset;
 			color: var(--InverseColor);
 			cursor: pointer;
+			margin-bottom: 16.5px;
+			margin-left: 76.5px;
+			margin-right: 83.5px;
 
 			&:is(:hover, :focus-visible) {
 				background-color: var(--InteractiveHoverColor);

--- a/src/components/home/articles/home-articles.css
+++ b/src/components/home/articles/home-articles.css
@@ -75,9 +75,9 @@
 		grid-row: 2;
 
 		/* layout */
-		inline-size: 20px;
-		block-size: 450px;
-		padding-inline: 5px;
+		inline-size: 5--step;
+		block-size: 112.5--step;
+		padding-inline: 1.25--step;
 		transition: 400ms opacity;
 
 		/* decoration */
@@ -136,8 +136,6 @@
 		flex-flow: column;
 		flex-shrink: 0;
 		inline-size: var(--article-size);
-		padding-block: 5--step;
-		padding-inline: 5--step;
 		scroll-snap-align: start;
 		padding: 0;
 	
@@ -168,8 +166,7 @@
 			font-size: 20--rpx;
 			font-weight: 500;
 			line-height: max(24 / 20);
-			padding-left: 22px;
-			padding-right: 26.5px;
+			padding-left: 5--step;
 		}
 
 		& p {
@@ -178,9 +175,8 @@
 
 			/* typography */
 			font-size: 14--rpx;
-			line-height: 16.41px;
-			padding-left: 22px;
-			padding-right: 22px;
+			line-height: 4.25--step;
+			padding-inline: 5--step;
 		}
 
 		& a {
@@ -200,9 +196,8 @@
 			box-shadow: var(--InteractiveColor) 0 0 0 1px inset;
 			color: var(--InverseColor);
 			cursor: pointer;
-			margin-bottom: 16.5px;
-			margin-left: 76.5px;
-			margin-right: 83.5px;
+			margin-bottom: 4.125--step;
+			margin-inline: 20--step;
 
 			&:is(:hover, :focus-visible) {
 				background-color: var(--InteractiveHoverColor);


### PR DESCRIPTION
Fixed the padding/margins/spacing on the articles body, text, and buttons. I couldn't get the spacing to be 88px like in the Figma design without there being a scroll bar, but I maxed out the space between the articles as close as I could. I noticed one interesting thing, there is border-radius: 3px 3px 0px 0px on 3 of the article images, but not the forth (which is the third image from the left). That matches the Figma design exactly. So I'm thinking there was a small error in the Figma file. 