### PR TITLE
(redesign): moved design token buttons to new line, updated text colo…

### DIFF
--- a/src/components/contribution-footer/contribution-footer.astro
+++ b/src/components/contribution-footer/contribution-footer.astro
@@ -7,7 +7,7 @@ import "./contribution-footer.css"
   <p>You can help improve this page, with updated information, guidance or fixes for typos and errors.</p>
   <ul>
     <!-- TODO - Resolve dynamic linking to edit on github repo -->
-    <li><a href="{{ meta.repo if meta.repo else 'https://github.com/RocketCommunicationsInc/astro' }}/edit/{{ meta.branch if meta.branch else 'main' }}/packages/astro-uxds/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
+    <li><a href="https://github.com/RocketCommunicationsInc/astro/edit/main/packages/astro-uxds/_content/components/accordion.md">Propose a change or fix to this page</a></li>
     <li><a href="/community/propose-a-change/">How to propose a change</a></li>
   </ul>
 </footer>

--- a/src/components/site-navigation/site-navigation.yml
+++ b/src/components/site-navigation/site-navigation.yml
@@ -40,7 +40,7 @@
       url: /patterns/notifications/
     - label: Data Visualization
       url: /patterns/data-visualization/
-    - label: Modeless panes
+    - label: Modeless Panes
       url: /patterns/modeless-panes/
     - label: Sample App
       url: /patterns/sample-app/
@@ -96,11 +96,11 @@
       url: /components/progress/
     - label: Push Button
       url: /components/push-button/
-    - label: Radio button
+    - label: Radio Button
       url: /components/radio-button/
     - label: Search
       url: /components/search/
-    - label: Segmented button
+    - label: Segmented Button
       url: /components/segmented-button/
     - label: Select
       url: /components/select/

--- a/src/pages/design-tokens/index.astro
+++ b/src/pages/design-tokens/index.astro
@@ -11,8 +11,11 @@ import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 	color: #4DACFF;
 }
 
-.text-blue-800 {
-	color: rgb(30, 64, 175);
+.text-teal-600 {
+	color: rgb(0, 159, 163)
+	/* Second Option? */
+	/* color: rgb(120, 109, 211) */
+	
 }
 
 .text-green-500 {
@@ -73,30 +76,30 @@ import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 		<tbody>
 			<tr>
 				<td> The <span class="font-bold text-brightblue-500">text</span>
-					<span class="font-bold text-blue-800">color</span> of a <span class="font-bold text-green-500">button</span> is #fffff. </td>
+					<span class="font-bold text-teal-600">color</span> of a <span class="font-bold text-green-500">button</span> is #fffff. </td>
 				<td>
-					<span class="font-bold text-green-500">button</span>-<span class="font-bold text-blue-800">color</span>-<span class="font-bold text-brightblue-500">text</span></td>
+					<span class="font-bold text-green-500">button</span>-<span class="font-bold text-teal-600">color</span>-<span class="font-bold text-brightblue-500">text</span></td>
 			</tr>
 			<tr>
 				<td>
 						The <span class="font-bold text-brightblue-500">background</span>
-					<span class="font-bold text-blue-800">color</span> for all <span class="font-bold text-blue-400">surface elements</span> is #fff.
+					<span class="font-bold text-teal-600">color</span> for all <span class="font-bold text-blue-400">surface elements</span> is #fff.
 					</td>
 				<td>
-					<span class="font-bold text-blue-800">color</span>-<span class="font-bold text-brightblue-500">background</span>-<span class="font-bold text-blue-400">surface</span>
+					<span class="font-bold text-teal-600">color</span>-<span class="font-bold text-brightblue-500">background</span>-<span class="font-bold text-blue-400">surface</span>
 				</td>
 			</tr>
 			<tr>
 				<td>Our <span class="font-bold text-blue-400">base</span>
-					<span class="font-bold text-blue-800">border radii</span> is 3px. </td>
+					<span class="font-bold text-teal-600">border radii</span> is 3px. </td>
 				<td>
-					<span class="font-bold text-blue-800">radius</span>-<span class="font-bold text-blue-400">base</span></td>
+					<span class="font-bold text-teal-600">radius</span>-<span class="font-bold text-blue-400">base</span></td>
 			</tr>
 			<tr>
 				<td>The <span class="font-bold text-brightblue-500">border</span>
-					<span class="font-bold text-blue-800">color</span> for a <span class="font-bold text-green-500">text input </span>when it is <span class="font-bold text-red-400">invalid</span> is #fff.</td>
+					<span class="font-bold text-teal-600">color</span> for a <span class="font-bold text-green-500">text input </span>when it is <span class="font-bold text-red-400">invalid</span> is #fff.</td>
 				<td>
-					<span class="font-bold text-green-500">input</span>-<span class="font-bold text-blue-800">color</span>-<span class="font-bold text-brightblue-500">border</span>-<span class="font-bold text-red-400">invalid</span>
+					<span class="font-bold text-green-500">input</span>-<span class="font-bold text-teal-600">color</span>-<span class="font-bold text-brightblue-500">border</span>-<span class="font-bold text-red-400">invalid</span>
 				</td>
 			</tr>
 		</tbody>
@@ -139,6 +142,7 @@ import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 
 	<h3>
 		I'm a designer creating a new component or piece of UI
+		<br>
 		<span class="token token__system">System (Preferred)</span>
 		<span class="token token__reference">Reference</span>
 	</h3>
@@ -149,6 +153,7 @@ import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 
 	<h3>
 		I'm a designer working in something that isn't Figma
+		<br>
 		<span class="token token__component">Component</span>
 	</h3>
 
@@ -156,6 +161,7 @@ import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 
 	<h3>
 		I'm a single developer working on some new UI
+		<br>
 		<span class="token token__system">System (Preferred)</span>
 		<span class="token token__reference">Reference</span>
 	</h3>
@@ -169,6 +175,7 @@ import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 
 	<h3>
 		I'm a developer who can't use Astro Web Components
+		<br>
 		<span class="token token__component">Component</span>
 	</h3>
 

--- a/src/pages/downloads.md
+++ b/src/pages/downloads.md
@@ -9,7 +9,7 @@ layout: project:layouts/docs/docs-layout.astro
 
 - Astro Component Source Code ([Git Repository](https://github.com/RocketCommunicationsInc/astro-components))
 - Astro UXDS Figma Page ([Figma](https://www.figma.com/community/file/1014254163928270411))
-- Astro Icons ([SVG](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components/src/icons) | [Figma](https://www.figma.com/community/file/1022883566772542677)
+- Astro Icons ([SVG](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/web-components/src/icons) | [Figma](https://www.figma.com/community/file/1022883566772542677))
 - Astro React Wrapper ([Git Repository](https://github.com/RocketCommunicationsInc/astro/tree/main/packages/react))
 - Astro React Starter Kit ([Git Repository](https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/react-starter/README.md))
 - Astro Svelte Starter Kit ([Git Repository](https://github.com/RocketCommunicationsInc/astro/blob/main/packages/starter-kits/svelte-starter/README.md))


### PR DESCRIPTION
On design tokens page:
Moved buttons under "common use cases" to new lines
Updated text-blue-800 to text-teal-600 for better visibility. (Have a second good option as well)

On downloads page: 
 Added closing parenthesis after Figma link in first section

On every page:
Updated "propose a change" link to direct you to same page as live site

In navigation menu:
Updated 3 items to have correct capitalization in yml file (however the changes don't reflect. Build?)