### PR TITLE
(redesign): fixing spacing under github links to be readable and clic…

### DIFF
--- a/src/pages/components/global-status-bar.md
+++ b/src/pages/components/global-status-bar.md
@@ -11,6 +11,7 @@ height: 150px
 
 ::storybook-demo
 
+<hr style="height:45px; visibility:hidden;" />
 The Global Status Bar is a full width view across the top of an application — an area commonly reserved for global status, global command and top-level navigation. The Global Status Bar often includes: Application Name, Monitoring Icons, Top Level Navigation and an Emergency Button.
 
 ## Rules of Thumb

--- a/src/pages/components/segmented-button.md
+++ b/src/pages/components/segmented-button.md
@@ -12,6 +12,7 @@ theme: true
 
 ::storybook-demo
 
+<hr style="height:70px; visibility:hidden;" />
 Segmented Buttons allow users to select one item at a time from two to four options. Selecting one option automatically turns off the last selection made. Segmented Buttons are mutually exclusive.
 
 ## Rules of Thumb

--- a/src/pages/components/select.md
+++ b/src/pages/components/select.md
@@ -13,6 +13,7 @@ theme: true
 
 ::storybook-demo
 
+<hr style="height:65px; visibility:hidden;" />
 When activated, Select Menus allow users to select a value from a list. Once a value is selected, the Select Menu displays the selected value.
 
 ## Rules of Thumb

--- a/src/pages/components/slider.md
+++ b/src/pages/components/slider.md
@@ -12,6 +12,7 @@ theme: true
 
 ::storybook-demo
 
+<hr style="height:65px; visibility:hidden;" />
 A Slider allows users to choose from a range of continuous and discrete values arranged from minimum to maximum.
 
 :::note

--- a/src/pages/components/status-symbol.md
+++ b/src/pages/components/status-symbol.md
@@ -13,6 +13,7 @@ class: color
 
 ::storybook-demo
 
+<hr style="height:65px; visibility:hidden;" />
 The Status Symbol combines color and shape to create a standard and consistent way to indicate the status of a device or feature.
 
 ![Astro Status Symbols in context of a modem list layout.](/img/components/icons-symbols-modems.png "Astro Status Symbols in context of a modem list layout.")

--- a/src/pages/components/switch.md
+++ b/src/pages/components/switch.md
@@ -12,6 +12,7 @@ theme: true
 
 ::storybook-demo
 
+<hr style="height:40px; visibility:hidden;" />
 A Switch toggles between two mutually exclusive states such as "On" or "Off." Unlike a Checkbox, a Switch initiates an action with immediate effect without requiring a "Save" or "Submit" action.
 
 ## Rules of Thumb

--- a/src/pages/components/tabs.md
+++ b/src/pages/components/tabs.md
@@ -12,6 +12,7 @@ theme: true
 
 ::storybook-demo
 
+<hr style="height:30px; visibility:hidden;" />
 Tabs in Astro applications are used to divide major areas of content and to indicate work process.
 
 ## Rules of Thumb

--- a/src/pages/components/textarea.md
+++ b/src/pages/components/textarea.md
@@ -13,6 +13,7 @@ theme: true
 
 ::storybook-demo
 
+<hr style="height:60px; visibility:hidden;" />
 Textareas are multi-line text inputs that allow for entering text in a larger area than a single-line text input would allow. They are typically used for multi-line input use cases like comments or feedback.
 
 ## Rules of Thumb


### PR DESCRIPTION
Fixed the spacing under the "Storybook" and "Github" links that are part of the storybook demo so they no longer overlap with the text underneath them on certain component pages