### PR TITLE
(fix): mobile nav width breaking on search

### DIFF
--- a/src/components/site-navigation/site-navigation.css
+++ b/src/components/site-navigation/site-navigation.css
@@ -15,11 +15,6 @@
 	/* Animation */
 	transition: inline-size 200ms;
 
-	&.-has-results {
-		/* Layout */
-		inline-size: min(50vw, 140--step);
-	}
-
 	@media (width < 800px) {
 		display: grid;
 
@@ -68,6 +63,11 @@
 		/* Behavior */
 		scroll-behavior: smooth;
 		scrollbar-gutter: stable;
+
+		&.-has-results {
+			/* Layout */
+			inline-size: min(50vw, 140--step);
+		}
 	}
 }
 


### PR DESCRIPTION
Mobile nav was getting cut in half when search was activated and the top navbar would stay cut if the search was open even if the nav was closed. The solution was a desktop style that was not properly scoped for only viewports in the non-mobile range. I scoped it. Tested in Chrome and emulator in Safari, all good.