### PR TITLE
(fix): Restore keyboard controls on search

### DIFF
--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -52,7 +52,8 @@ requestAnimationFrame(() => {
 	let searchForm = document.getElementById('search')!
 	let searchResults = document.getElementById('search-results')!
 	let searchElement = <HTMLInputElement>document.getElementById('search-field')!
-	let resultChildren: any[] | NodeListOf<Element>
+	let resultChildren: any[] | NodeListOf<Element> = []
+	const navigation = searchForm.closest('.p-navigation')!
 
 	if (searchForm) {
 		searchForm.addEventListener('submit', (event) => {
@@ -77,7 +78,6 @@ requestAnimationFrame(() => {
 				searchFrame = requestAnimationFrame(async () => {
 					const results = await searchUtils.search(event.target.value)
 					const hasResults = Boolean(results && results.items.length)
-					const navigation = searchForm.closest('.p-navigation')!
 
 					searchForm.classList.toggle('-has-results', hasResults)
 					navigation.classList.toggle('-has-results', hasResults)
@@ -102,8 +102,9 @@ requestAnimationFrame(() => {
 					resultChildren = searchResults.querySelectorAll('.listitem')
 					resultChildren.forEach((result, index) => {
 						if (index === 0) {
-							result.setAttribute('aria-selected', '')
-							console.log(result)
+							result.setAttribute('aria-selected', 'true')
+						} else {
+							result.setAttribute('aria-selected', 'false')
 						}
 					})
 				})
@@ -111,19 +112,17 @@ requestAnimationFrame(() => {
 		})
 		let indexNumber = 0
 		const onKeydown = (event: { key: string; preventDefault: () => void }) => {
-			const navigation = searchForm.closest('.p-navigation')!
-			resultChildren = searchResults.querySelectorAll('.listitem')
 			if (resultChildren.length > 0) {
 				if (event.key === 'ArrowDown') {
 					event.preventDefault()
-					if (indexNumber <= 3) {
+					if (indexNumber < (resultChildren.length - 1)) {
 						indexNumber++
 					}
-					resultChildren.forEach((result, index) => {
+					resultChildren.forEach((result: HTMLElement, index: number) => {
 						if (index === indexNumber) {
-							result.setAttribute('aria-selected', '')
+							result.setAttribute('aria-selected', 'true')
 						} else {
-							result.removeAttribute('aria-selected')
+							result.setAttribute('aria-selected', 'false')
 						}
 					})
 				} else if (event.key === 'ArrowUp') {
@@ -131,20 +130,21 @@ requestAnimationFrame(() => {
 					if (indexNumber >= 1) {
 						indexNumber--
 					}
-					resultChildren.forEach((result, index) => {
+					resultChildren.forEach((result: HTMLElement, index: number) => {
 						if (index === indexNumber) {
-							result.setAttribute('aria-selected', '')
+							result.setAttribute('aria-selected', 'true')
 						} else {
-							result.removeAttribute('aria-selected')
+							result.setAttribute('aria-selected', 'false')
 						}
 					})
 				} else if (event.key === 'Enter') {
-					resultChildren.forEach((result) => {
-						if (result.hasAttribute('aria-selected')) {
+					resultChildren.forEach((result: HTMLElement) => {
+						if (result.getAttribute('aria-selected') === 'true') {
 							result.querySelector('a')?.click()
 						}
 					})
 				} else if (event.key === 'Escape') {
+					// clears the search control and removes search results
 					searchElement.value = ''
 					searchResults.replaceChildren()
 					searchForm.classList.remove('-has-results')

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -45,7 +45,8 @@ requestAnimationFrame(() => {
 			html: utils.html,
 		}
 	}
-
+	/** The modifier key of the platform ('Meta' for Apple devices, otherwise 'Control'). */
+	const modifierKey = /^(MacIntel|iPhone)$/.test(navigator.platform) ? 'metaKey' : 'ctrlKey'
 	let search: Promise<SearchUtils>
 	let searchFrame = 0
 	let searchForm = document.getElementById('search')!
@@ -60,7 +61,7 @@ requestAnimationFrame(() => {
 
 	if (searchElement) {
 		document.addEventListener('keydown', (event) => {
-			if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
+			if (event.key === 'k' && event[modifierKey]) {
 				event.preventDefault()
 				searchElement.focus()
 			}
@@ -135,7 +136,7 @@ requestAnimationFrame(() => {
 									result.querySelector('a')?.click()
 								} else if (event.key === 'Escape') {
 									searchElement.value = ''
-									searchResults.replaceChildren('')
+									searchResults.replaceChildren()
 									searchForm.classList.remove('-has-results')
 									navigation.classList.remove('-has-results')
 								}

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -111,7 +111,7 @@ requestAnimationFrame(() => {
 			})
 		})
 		let indexNumber = 0
-		const onKeydown = (event: { key: string; preventDefault: () => void }) => {
+		const onKeydown = (event: KeyboardEvent) => {
 			if (resultChildren.length > 0) {
 				if (event.key === 'ArrowDown') {
 					event.preventDefault()

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -52,6 +52,7 @@ requestAnimationFrame(() => {
 	let searchForm = document.getElementById('search')!
 	let searchResults = document.getElementById('search-results')!
 	let searchElement = <HTMLInputElement>document.getElementById('search-field')!
+	let resultChildren: any[] | NodeListOf<Element>
 
 	if (searchForm) {
 		searchForm.addEventListener('submit', (event) => {
@@ -98,56 +99,59 @@ requestAnimationFrame(() => {
 					}
 
 					searchResults.replaceChildren(hdom)
-
-					let resultChildren = searchResults.querySelectorAll('.listitem')
-					if (resultChildren) {
-						resultChildren.forEach((result, index) => {
-							if (index === 0) {
-								result.setAttribute('aria-selected', '')
-							}
-						})
-						let indexNumber = 0
-						searchElement.onkeydown = (event) => {
-							if (event.key === 'ArrowDown') {
-								event.preventDefault()
-								if (indexNumber <= 3) {
-									indexNumber++
-								}
-								resultChildren.forEach((result, index) => {
-									if (index === indexNumber) {
-										result.setAttribute('aria-selected', '')
-									} else {
-										result.removeAttribute('aria-selected')
-									}
-								})
-							} else if (event.key === 'ArrowUp') {
-								event.preventDefault()
-								if (indexNumber >= 1) {
-									indexNumber--
-								}
-								resultChildren.forEach((result, index) => {
-									if (index === indexNumber) {
-										result.setAttribute('aria-selected', '')
-									} else {
-										result.removeAttribute('aria-selected')
-									}
-								})
-							} else if (event.key === 'Enter') {
-								resultChildren.forEach((result) => {
-									if (result.hasAttribute('aria-selected')) {
-										result.querySelector('a')?.click()
-									}
-								})
-							} else if (event.key === 'Escape') {
-								searchElement.value = ''
-								searchResults.replaceChildren()
-								searchForm.classList.remove('-has-results')
-								navigation.classList.remove('-has-results')
-							}
+					resultChildren = searchResults.querySelectorAll('.listitem')
+					resultChildren.forEach((result, index) => {
+						if (index === 0) {
+							result.setAttribute('aria-selected', '')
+							console.log(result)
 						}
-					}
+					})
 				})
 			})
 		})
+		let indexNumber = 0
+		const onKeydown = (event: { key: string; preventDefault: () => void }) => {
+			const navigation = searchForm.closest('.p-navigation')!
+			resultChildren = searchResults.querySelectorAll('.listitem')
+			if (resultChildren.length > 0) {
+				if (event.key === 'ArrowDown') {
+					event.preventDefault()
+					if (indexNumber <= 3) {
+						indexNumber++
+					}
+					resultChildren.forEach((result, index) => {
+						if (index === indexNumber) {
+							result.setAttribute('aria-selected', '')
+						} else {
+							result.removeAttribute('aria-selected')
+						}
+					})
+				} else if (event.key === 'ArrowUp') {
+					event.preventDefault()
+					if (indexNumber >= 1) {
+						indexNumber--
+					}
+					resultChildren.forEach((result, index) => {
+						if (index === indexNumber) {
+							result.setAttribute('aria-selected', '')
+						} else {
+							result.removeAttribute('aria-selected')
+						}
+					})
+				} else if (event.key === 'Enter') {
+					resultChildren.forEach((result) => {
+						if (result.hasAttribute('aria-selected')) {
+							result.querySelector('a')?.click()
+						}
+					})
+				} else if (event.key === 'Escape') {
+					searchElement.value = ''
+					searchResults.replaceChildren()
+					searchForm.classList.remove('-has-results')
+					navigation.classList.remove('-has-results')
+				}
+			}
+		}
+		searchElement.addEventListener('keydown', onKeydown)
 	}
 })

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -61,6 +61,7 @@ requestAnimationFrame(() => {
 	if (searchElement) {
 		document.addEventListener('keydown', (event) => {
 			if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
+				event.preventDefault()
 				searchElement.focus()
 			}
 		})
@@ -97,17 +98,37 @@ requestAnimationFrame(() => {
 
 					searchResults.replaceChildren(hdom)
 					const resultChildren = searchResults.querySelectorAll('.listitem a')
+					if (hasResults) {
+						onkeydown = (event) => {
+							if (event.key === 'Tab') {
+								event.preventDefault()
+								const firstResult = resultChildren[0] as HTMLElement
+								firstResult.focus()
+							}
+						}
+					}
 					resultChildren.forEach((result) => {
 						result.addEventListener('focus', (event) => {
 							onkeydown = (event) => {
-								if (event.key === 'ArrowDown') {
+								let keys = {
+									tab: false,
+									shift: false,
+								};
+								if (event.key === 'Tab') {
+									keys.tab = true;
+								}
+								if (event.key === 'Shift') {
+									keys.shift = true;
+								}
+								if (event.key === 'Tab' || event.key === 'ArrowDown') {
 									event.preventDefault()
+									console.log(event.key)
 									if (result.parentElement?.nextSibling) {
 										const nextSibling = result.parentElement?.nextSibling as HTMLElement
 										const nextresult = nextSibling.querySelector('a')
 										nextresult?.focus()
 									}
-								} else if (event.key === 'ArrowUp') {
+								} else if (event.key === 'ArrowUp' || (keys.tab && keys.shift)) {
 									event.preventDefault()
 									if (result.parentElement?.previousSibling) {
 										const previousSibling = result.parentElement?.previousSibling as HTMLElement

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -89,32 +89,6 @@ requestAnimationFrame(() => {
 								link.href.replace(/^https:\/\/www\.astrouxds\.com/, '').replace(/\/readme\//, '/')
 							)
 						}
-						link.addEventListener('focus', (event) => {
-							document.addEventListener('keydown', (event) => {
-								if (event.key === 'ArrowDown') {
-									event.preventDefault()
-									if (link.parentElement?.nextSibling) {
-										const nextSibling = link.parentElement?.nextSibling as HTMLElement
-										const nextLink = nextSibling.querySelector('a')
-										nextLink?.focus()
-									}
-								} else if (event.key === 'ArrowUp') {
-									event.preventDefault()
-									if (link.parentElement?.previousSibling) {
-										const previousSibling = link.parentElement?.previousSibling as HTMLElement
-										const previousLink = previousSibling.querySelector('a')
-										previousLink?.focus()
-									}
-								} else if (event.key === 'Enter') {
-									link.click()
-								} else if (event.key === 'Escape') {
-									searchElement.value = ''
-									searchResults.replaceChildren('')
-									searchForm.classList.remove('-has-results')
-									navigation.classList.remove('-has-results')
-								}
-							})
-						})
 
 						link.parentNode!.addEventListener('click', (event) => {
 							link.click()
@@ -122,6 +96,35 @@ requestAnimationFrame(() => {
 					}
 
 					searchResults.replaceChildren(hdom)
+					const resultChildren = searchResults.querySelectorAll('.listitem a')
+					resultChildren.forEach((result) => {
+						result.addEventListener('focus', (event) => {
+							onkeydown = (event) => {
+								if (event.key === 'ArrowDown') {
+									event.preventDefault()
+									if (result.parentElement?.nextSibling) {
+										const nextSibling = result.parentElement?.nextSibling as HTMLElement
+										const nextresult = nextSibling.querySelector('a')
+										nextresult?.focus()
+									}
+								} else if (event.key === 'ArrowUp') {
+									event.preventDefault()
+									if (result.parentElement?.previousSibling) {
+										const previousSibling = result.parentElement?.previousSibling as HTMLElement
+										const previousresult = previousSibling.querySelector('a')
+										previousresult?.focus()
+									}
+								} else if (event.key === 'Enter') {
+									result.querySelector('a')?.click()
+								} else if (event.key === 'Escape') {
+									searchElement.value = ''
+									searchResults.replaceChildren('')
+									searchForm.classList.remove('-has-results')
+									navigation.classList.remove('-has-results')
+								}
+							}
+						})
+					})
 				})
 			})
 		})

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -89,6 +89,32 @@ requestAnimationFrame(() => {
 								link.href.replace(/^https:\/\/www\.astrouxds\.com/, '').replace(/\/readme\//, '/')
 							)
 						}
+						link.addEventListener('focus', (event) => {
+							document.addEventListener('keydown', (event) => {
+								if (event.key === 'ArrowDown') {
+									event.preventDefault()
+									if (link.parentElement?.nextSibling) {
+										const nextSibling = link.parentElement?.nextSibling as HTMLElement
+										const nextLink = nextSibling.querySelector('a')
+										nextLink?.focus()
+									}
+								} else if (event.key === 'ArrowUp') {
+									event.preventDefault()
+									if (link.parentElement?.previousSibling) {
+										const previousSibling = link.parentElement?.previousSibling as HTMLElement
+										const previousLink = previousSibling.querySelector('a')
+										previousLink?.focus()
+									}
+								} else if (event.key === 'Enter') {
+									link.click()
+								} else if (event.key === 'Escape') {
+									searchElement.value = ''
+									searchResults.replaceChildren('')
+									searchForm.classList.remove('-has-results')
+									navigation.classList.remove('-has-results')
+								}
+							})
+						})
 
 						link.parentNode!.addEventListener('click', (event) => {
 							link.click()

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -98,65 +98,83 @@ requestAnimationFrame(() => {
 					}
 
 					searchResults.replaceChildren(hdom)
-					const resultChildren = searchResults.querySelectorAll('.listitem a')
-					if (hasResults) {
-						onkeydown = (event) => {
-							if (event.key === 'Tab') {
-								event.preventDefault()
-								const firstResult = resultChildren[0] as HTMLElement
-								firstResult.focus()
-							}
-						}
-					}
-					let keyArray: string[] = []
-					resultChildren.forEach((result) => {
-						result.addEventListener('focus', (event) => {
-							onkeydown = (event) => {
-								if (event.key === 'Shift') {
-									keyArray.push(event.key)
-								}
-								if (event.key === 'Tab') {
-									keyArray.push(event.key)
-								}
-								if (event.key === 'ArrowUp' || (keyArray.includes('Shift') && keyArray.includes('Tab'))) {
-									event.preventDefault()
-									if (result.parentElement?.previousSibling) {
-										const previousSibling = result.parentElement?.previousSibling as HTMLElement
-										const previousresult = previousSibling.querySelector('a')
-										previousresult?.focus()
-									}
-								} else if (event.key === 'ArrowDown' || (!keyArray.includes('Shift') && keyArray.includes('Tab'))) {
-									event.preventDefault()
-									if (result.parentElement?.nextSibling) {
-										const nextSibling = result.parentElement?.nextSibling as HTMLElement
-										const nextresult = nextSibling.querySelector('a')
-										nextresult?.focus()
-									}
-								} else if (event.key === 'Enter') {
-									result.querySelector('a')?.click()
-								} else if (event.key === 'Escape') {
-									searchElement.value = ''
-									searchResults.replaceChildren()
-									searchForm.classList.remove('-has-results')
-									navigation.classList.remove('-has-results')
-								}
-							}
-							onkeyup = (event) => {
-								if (event.key === 'Shift') {
-									const shiftKey = keyArray.indexOf('Shift');
-									if (shiftKey > -1) {
-									keyArray.splice(shiftKey, 1)
-									}
-								}
-								if (event.key === 'Tab') {
-									const tabKey = keyArray.indexOf('Tab');
-									if (tabKey > -1) {
-									keyArray.splice(tabKey, 1)
-									}
-								}
+
+					let resultChildren = searchResults.querySelectorAll('.listitem')
+					if (resultChildren) {
+						resultChildren.forEach((result, index) => {
+							if (index === 0) {
+								result.setAttribute('aria-selected', '')
 							}
 						})
-					})
+						let indexNumber = 0
+						onkeydown = (event) => {
+							if (event.key === 'ArrowDown') {
+								event.preventDefault()
+								if (indexNumber <= 3) {
+									indexNumber++
+								}
+								resultChildren.forEach((result, index) => {
+									if (index === indexNumber) {
+										result.setAttribute('aria-selected', '')
+									} else {
+										result.removeAttribute('aria-selected')
+									}
+								})
+							} else if (event.key === 'ArrowUp') {
+								event.preventDefault()
+								if (indexNumber >= 1) {
+									indexNumber--
+								}
+								resultChildren.forEach((result, index) => {
+									if (index === indexNumber) {
+										result.setAttribute('aria-selected', '')
+									} else {
+										result.removeAttribute('aria-selected')
+									}
+								})
+							} else if (event.key === 'Enter') {
+								resultChildren.forEach((result) => {
+									if (result.hasAttribute('aria-selected')) {
+										result.querySelector('a')?.click()
+									}
+								})
+							} else if (event.key === 'Escape') {
+								searchElement.value = ''
+								searchResults.replaceChildren()
+								searchForm.classList.remove('-has-results')
+								navigation.classList.remove('-has-results')
+							}
+						}
+
+						// resultChildren.forEach((result) => {
+						// 	result.addEventListener('focus', (event) => {
+						// 		onkeydown = (event) => {
+						// 			if (event.key === 'ArrowUp') {
+						// 				event.preventDefault()
+						// 				if (result.parentElement?.previousSibling) {
+						// 					const previousSibling = result.parentElement?.previousSibling as HTMLElement
+						// 					const previousresult = previousSibling.querySelector('a')
+						// 					previousresult?.focus()
+						// 				}
+						// 			} else if (event.key === 'ArrowDown') {
+						// 				event.preventDefault()
+						// 				if (result.parentElement?.nextSibling) {
+						// 					const nextSibling = result.parentElement?.nextSibling as HTMLElement
+						// 					const nextresult = nextSibling.querySelector('a')
+						// 					nextresult?.focus()
+						// 				}
+						// 			} else if (event.key === 'Enter') {
+						// 				result.querySelector('a')?.click()
+						// 			} else if (event.key === 'Escape') {
+						// 				searchElement.value = ''
+						// 				searchResults.replaceChildren()
+						// 				searchForm.classList.remove('-has-results')
+						// 				navigation.classList.remove('-has-results')
+						// 			}
+						// 		}
+						// 	})
+						// })
+					}
 				})
 			})
 		})

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -107,7 +107,7 @@ requestAnimationFrame(() => {
 							}
 						})
 						let indexNumber = 0
-						onkeydown = (event) => {
+						searchElement.onkeydown = (event) => {
 							if (event.key === 'ArrowDown') {
 								event.preventDefault()
 								if (indexNumber <= 3) {
@@ -145,35 +145,6 @@ requestAnimationFrame(() => {
 								navigation.classList.remove('-has-results')
 							}
 						}
-
-						// resultChildren.forEach((result) => {
-						// 	result.addEventListener('focus', (event) => {
-						// 		onkeydown = (event) => {
-						// 			if (event.key === 'ArrowUp') {
-						// 				event.preventDefault()
-						// 				if (result.parentElement?.previousSibling) {
-						// 					const previousSibling = result.parentElement?.previousSibling as HTMLElement
-						// 					const previousresult = previousSibling.querySelector('a')
-						// 					previousresult?.focus()
-						// 				}
-						// 			} else if (event.key === 'ArrowDown') {
-						// 				event.preventDefault()
-						// 				if (result.parentElement?.nextSibling) {
-						// 					const nextSibling = result.parentElement?.nextSibling as HTMLElement
-						// 					const nextresult = nextSibling.querySelector('a')
-						// 					nextresult?.focus()
-						// 				}
-						// 			} else if (event.key === 'Enter') {
-						// 				result.querySelector('a')?.click()
-						// 			} else if (event.key === 'Escape') {
-						// 				searchElement.value = ''
-						// 				searchResults.replaceChildren()
-						// 				searchForm.classList.remove('-has-results')
-						// 				navigation.classList.remove('-has-results')
-						// 			}
-						// 		}
-						// 	})
-						// })
 					}
 				})
 			})

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -107,33 +107,29 @@ requestAnimationFrame(() => {
 							}
 						}
 					}
+					let keyArray: string[] = []
 					resultChildren.forEach((result) => {
 						result.addEventListener('focus', (event) => {
 							onkeydown = (event) => {
-								let keys = {
-									tab: false,
-									shift: false,
-								};
-								if (event.key === 'Tab') {
-									keys.tab = true;
-								}
 								if (event.key === 'Shift') {
-									keys.shift = true;
+									keyArray.push(event.key)
 								}
-								if (event.key === 'Tab' || event.key === 'ArrowDown') {
-									event.preventDefault()
-									console.log(event.key)
-									if (result.parentElement?.nextSibling) {
-										const nextSibling = result.parentElement?.nextSibling as HTMLElement
-										const nextresult = nextSibling.querySelector('a')
-										nextresult?.focus()
-									}
-								} else if (event.key === 'ArrowUp' || (keys.tab && keys.shift)) {
+								if (event.key === 'Tab') {
+									keyArray.push(event.key)
+								}
+								if (event.key === 'ArrowUp' || (keyArray.includes('Shift') && keyArray.includes('Tab'))) {
 									event.preventDefault()
 									if (result.parentElement?.previousSibling) {
 										const previousSibling = result.parentElement?.previousSibling as HTMLElement
 										const previousresult = previousSibling.querySelector('a')
 										previousresult?.focus()
+									}
+								} else if (event.key === 'ArrowDown' || (!keyArray.includes('Shift') && keyArray.includes('Tab'))) {
+									event.preventDefault()
+									if (result.parentElement?.nextSibling) {
+										const nextSibling = result.parentElement?.nextSibling as HTMLElement
+										const nextresult = nextSibling.querySelector('a')
+										nextresult?.focus()
 									}
 								} else if (event.key === 'Enter') {
 									result.querySelector('a')?.click()
@@ -142,6 +138,20 @@ requestAnimationFrame(() => {
 									searchResults.replaceChildren('')
 									searchForm.classList.remove('-has-results')
 									navigation.classList.remove('-has-results')
+								}
+							}
+							onkeyup = (event) => {
+								if (event.key === 'Shift') {
+									const shiftKey = keyArray.indexOf('Shift');
+									if (shiftKey > -1) {
+									keyArray.splice(shiftKey, 1)
+									}
+								}
+								if (event.key === 'Tab') {
+									const tabKey = keyArray.indexOf('Tab');
+									if (tabKey > -1) {
+									keyArray.splice(tabKey, 1)
+									}
 								}
 							}
 						})

--- a/src/components/site-search/site-search.client.ts
+++ b/src/components/site-search/site-search.client.ts
@@ -59,13 +59,17 @@ requestAnimationFrame(() => {
 	}
 
 	if (searchElement) {
+		document.addEventListener('keydown', (event) => {
+			if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
+				searchElement.focus()
+			}
+		})
 		searchElement.addEventListener('focus', (event) => {
 			search = search || createSearch()
 		})
 
 		searchElement.addEventListener('input', (event: InputEvent & { target: HTMLInputElement }) => {
 			cancelAnimationFrame(searchFrame)
-
 			search.then(searchUtils => {
 				searchFrame = requestAnimationFrame(async () => {
 					const results = await searchUtils.search(event.target.value)

--- a/src/components/site-search/site-search.css
+++ b/src/components/site-search/site-search.css
@@ -119,7 +119,7 @@
 			cursor: pointer;
 		}
 
-		&[aria-selected] {
+		&[aria-selected="true"] {
 			/* Appearance */
 			background-color: var(--InteractiveColor);
 			color: var(--InverseColor);
@@ -168,7 +168,7 @@
 		color: currentColor;
 	}
 
-	& .listitem[aria-selected] mark {
+	& .listitem[aria-selected="true"] mark {
 		/* Appearance */
 		color: currentColor;
 	}
@@ -178,7 +178,7 @@
 		outline: none;
 	}
 
-	& .listitem[aria-selected] a {
+	& .listitem[aria-selected="true"] a {
 		/* Appearance */
 		outline: none;
 	}
@@ -188,7 +188,7 @@
 		color: var(--PlaceholderColor);
 	}
 
-	& .listitem[aria-selected] svg {
+	& .listitem[aria-selected="true"] svg {
 		/* Appearance */
 		color: currentColor;
 	}

--- a/src/components/site-search/site-search.css
+++ b/src/components/site-search/site-search.css
@@ -118,6 +118,13 @@
 			color: var(--InverseColor);
 			cursor: pointer;
 		}
+
+		&[aria-selected] {
+			/* Appearance */
+			background-color: var(--InteractiveColor);
+			color: var(--InverseColor);
+			cursor: pointer;
+		}
 	}
 
 	& .search-result-icon {
@@ -161,7 +168,17 @@
 		color: currentColor;
 	}
 
+	& .listitem[aria-selected] mark {
+		/* Appearance */
+		color: currentColor;
+	}
+
 	& .listitem:is(:hover, :focus-within) a {
+		/* Appearance */
+		outline: none;
+	}
+
+	& .listitem[aria-selected] a {
 		/* Appearance */
 		outline: none;
 	}
@@ -169,5 +186,10 @@
 	& .listitem:not(:hover, :focus-within) svg {
 		/* Appearance */
 		color: var(--PlaceholderColor);
+	}
+
+	& .listitem[aria-selected] svg {
+		/* Appearance */
+		color: currentColor;
 	}
 }


### PR DESCRIPTION
Our new search did not have some of the keyboard controls that the search on the old website had. This PR now allows a keyboard user to:

- focus search input on cmd + k or ctrl + k
- ArrowUp and ArrowDown navigate results once the first result is focused.
- Enter selects result
- Escape clears results and search input