### PR TITLE
(fix): Removing recommendations to include title attribute

### DIFF
--- a/src/pages/components/icons-and-symbols.md
+++ b/src/pages/components/icons-and-symbols.md
@@ -19,7 +19,7 @@ Each of these must be easily identifiable by users and also be immediately disti
 Astro’s icons have been designed to utilize the Astro Status System.
 
 :::note
-Monitoring Icons must include a label, a title attribute in the HTML and a status indicator. When used in a light theme status indicators must also include a 1 pixel border around the status indicator set to rgba(0,0,0,0.5)
+Monitoring Icons must include a label, and a status indicator. When used in a light theme status indicators must also include a 1 pixel border around the status indicator set to rgba(0,0,0,0.5)
 :::
 
 ## Astro Icon Classes

--- a/src/pages/components/status-symbol.md
+++ b/src/pages/components/status-symbol.md
@@ -24,8 +24,6 @@ The Status Symbol combines color and shape to create a standard and consistent w
 - Use the highest color possible if multiple statuses are consolidated. For example, if the statuses of underlying components are green, yellow, and red, the consolidated indicator is red.
 
 :::note
-Adding a title attribute to status elements can improve accessibility by offering additional information about the status when the user hovers over the element or when used in conjunction with a screen reader.
-
 Place your cursor over any Status Symbol above to see an example.
 :::
 


### PR DESCRIPTION
The Status Symbol and Icons and Symbols page both carried recommendations to include the title attribute to increase accessibility. This is no longer recommended so these sections and references were removed from each page.