### PR TITLE
docs(icons-and-symbols): fix status symbol border color

### DIFF
--- a/src/pages/components/icons-and-symbols.md
+++ b/src/pages/components/icons-and-symbols.md
@@ -17,7 +17,7 @@ Each of these must be easily identifiable by users and also be immediately disti
 Astro’s icons have been designed to utilize the Astro Status System.
 
 :::note
-Monitoring Icons must include a label, and a status indicator. When used in a light theme status indicators must also include a 1 pixel border around the status indicator set to rgba(0,0,0,0.5)
+Monitoring Icons must include a label, and a status indicator. When used in a light theme status indicators must also include a border around the status indicator as assigned in Astro's [Component Design Tokens](design-tokens/component).
 :::
 
 ## Astro Icon Classes


### PR DESCRIPTION
Corrects an info box that had the wrong information for what color the borders of status symbols should be in light theme.