### PR TITLE
fix(compliance): Removing word 'new' from compliance UI on dialog and focus state pages

### DIFF
--- a/src/components/compliance/compliance-aside.css
+++ b/src/components/compliance/compliance-aside.css
@@ -45,6 +45,42 @@
 
 		& .-details {
 			grid-column: 2 / 3;
+
+			& .compliance-status {
+				display: block;
+
+				/* Layout */
+				margin-block-start: 1--step;
+
+				/* Text */
+				font-size: 12--rpx;
+				font-weight: 700;
+				line-height: calc(16 / 12);
+				text-transform: uppercase;
+
+				/* Appearance */
+				border-radius: var(--EdgeRadius);
+
+				&.-deprecated {
+					/* Appearance */
+					color: var(--Grey500Color);
+				}
+
+				&.-under-review {
+					/* Appearance */
+					color: #c8102e;
+				}
+
+				&.-updated {
+					/* Appearance */
+					color: #786dd3;
+				}
+
+				&.-new {
+					/* Appearance */
+					color: #005a00;
+				}
+			}
 		}
 	}
 }

--- a/src/data/compliance.json
+++ b/src/data/compliance.json
@@ -187,13 +187,13 @@
 						{
 							"numeral": 1,
 							"rule": "There shall be only one Focus State displayed on the screen at any time.",
-							"status": "new",
+							"status": "current",
 							"tier": 2
 						},
 						{
 							"numeral": 2,
 							"rule": "The Focus State shall encompass only the part of the target UI element that is interactive.",
-							"status": "new",
+							"status": "current",
 							"tier": 3
 						}
 					]
@@ -364,7 +364,7 @@
 						{
 							"numeral": 7,
 							"rule": "Dialogs must be actively closed by the user — self-dismissing dialogs shall not be used.",
-							"status": "new",
+							"status": "current",
 							"tier": 3
 						}
 					]

--- a/src/data/compliance.json
+++ b/src/data/compliance.json
@@ -187,13 +187,13 @@
 						{
 							"numeral": 1,
 							"rule": "There shall be only one Focus State displayed on the screen at any time.",
-							"status": "current",
+							"status": "new",
 							"tier": 2
 						},
 						{
 							"numeral": 2,
 							"rule": "The Focus State shall encompass only the part of the target UI element that is interactive.",
-							"status": "current",
+							"status": "new",
 							"tier": 3
 						}
 					]
@@ -364,7 +364,7 @@
 						{
 							"numeral": 7,
 							"rule": "Dialogs must be actively closed by the user — self-dismissing dialogs shall not be used.",
-							"status": "current",
+							"status": "new",
 							"tier": 3
 						}
 					]


### PR DESCRIPTION
There was a trailing 'new' in the compliance UI box at the bottom of the Dialog and Focus State pages. This is the rule status and it was un-styled. I have copied over the styles from the Compliance page so that they now show up in the Compliance Aside.