### PR TITLE
Github links on site fix

### DIFF
--- a/src/layouts/component-docs/component-docs-layout.astro
+++ b/src/layouts/component-docs/component-docs-layout.astro
@@ -4,7 +4,7 @@ import globalData from 'project:data/global.json'
 import './component-docs-layout.css'
 
 const {
-	designSystem: {
+	components: {
 		repository: GitHubRepoURL,
 		repositoryBranch: GitHubRepoBranch,
 	},


### PR DESCRIPTION
[ASTRO-5286](https://rocketcom.atlassian.net/browse/ASTRO-5286)

The GitHub links in the storybook demos on the component pages were broke. That is because they were taking their repo metadata from the wrong data point in global.json. I've updated the location that the repo comes from and as a result all links should be fixed. 