### PR TITLE
chore(icon-library): Sorting icons in their groups alphabetically

### DIFF
--- a/src/components/icon-search/parts/icon-groups.astro
+++ b/src/components/icon-search/parts/icon-groups.astro
@@ -8,7 +8,7 @@ import scriptURL from './icon-groups.js?url'
 		<article class="-group">
 			<h2 class="-group-heading">{name}</h2>
 			<div class="-icons">
-				<For of={Object.entries(icons)}>{([ id, { name, html } ]) => (
+				<For of={Object.entries(icons).sort()}>{([ id, { name, html } ]) => (
 					<figure class="icon" tabindex="0">
 						<svg aria-label={name}><use href={`#icon-${id}`} /></svg>
 						<figcaption>{name}</figcaption>


### PR DESCRIPTION
This is a one-line change that sorts the icons in their groups alphabetically. It does _not_ sort the groups alphabetically as then Astro would not be first, and I think it should be.