### PR TITLE
fix transpile error for media query

### DIFF
--- a/src/components/icon-search/icon-search.css
+++ b/src/components/icon-search/icon-search.css
@@ -39,7 +39,7 @@
 		--icon-size: 50px;
 	}
 
-	@media (1600px <= width) {
+	@media (width >= 1600px) {
 		--grid-size: 6;
 		--icon-size: 50px;
 	}


### PR DESCRIPTION
icon library in safari at screen sizes over 1600 broke.. Turns out that it wasn't polyfilling a media query correctly. I swapped it around and it figured itself out.