### PR TITLE
Remove `icon-` prefix from icons

### DIFF
--- a/src/components/icon-search/parts/side-panel.ts
+++ b/src/components/icon-search/parts/side-panel.ts
@@ -230,7 +230,7 @@ class IconPanelInternals {
 		const viewBox = symbolElement.getAttribute('viewBox')!
 
 		/** ID of the current icon web component. */
-		const id = this.id = symbolElement.getAttribute('id')!.replace(/^#icon-/, '')
+		const id = this.id = symbolElement.getAttribute('id')!.replace(/^icon-/, '')
 
 		const fileName = id + '.svg'
 


### PR DESCRIPTION
This removes the `icon-` prefix from icon IDs, as this prefix is not actually found in our web components.

[🌐 Preview](https://deploy-preview-113--astrouxds.netlify.app/icon-library/)