### PR TITLE
fix(event calendar) All day events now always show on the first day

### DIFF
--- a/src/components/home/community/home-community-events.astro
+++ b/src/components/home/community/home-community-events.astro
@@ -1,13 +1,14 @@
 ---
 import { Sanitizer } from 'project:utils/sanitizer.js'
 import { For, When } from '@astropub/flow';
-import { fetchGoogleCalendarEvents } from './home-community-events.constants.js'
+import { fetchGoogleCalendarEvents, getDate } from './home-community-events.constants.js'
 import eventToggleHandler from './home-community-events.eventToggleHandler.js?url'
 
 /** Google Calendar Events. */
 const calendarEvents = await fetchGoogleCalendarEvents()
 
 const sanitizer = new Sanitizer()
+
 ---
 <section class="p-community-events">
 	<h4>Upcoming Events</h4>
@@ -15,11 +16,13 @@ const sanitizer = new Sanitizer()
 		<For of={calendarEvents}>{calendarEvent => (
 			<article class="p-community-event">
 				<small class="p-community-event-date">
-					<span class="-date">{
-						new Date(calendarEvent.start.date || calendarEvent.start.dateTime).toLocaleString('en-US', {
+					<span class="-date">{calendarEvent.start.date ? getDate(calendarEvent.start.date)
+
+						: new Date( calendarEvent.start.dateTime).toLocaleString('en-US', {
 							day: '2-digit',
 							month: '2-digit',
 							year: 'numeric',
+							timeZone: 'PST'
 						})
 					}</span>
 					{
@@ -33,9 +36,8 @@ const sanitizer = new Sanitizer()
 									})
 								}</span>
 							)
-						: calendarEvent.start.date
-							? <span class="-time">All Day!</span>
-						: <Fragment />
+						: <span class="-time">All Day!</span>
+						<Fragment />
 					}
 				</small>
 				<hgroup class="p-community-event-heading">

--- a/src/components/home/community/home-community-events.constants.ts
+++ b/src/components/home/community/home-community-events.constants.ts
@@ -32,6 +32,12 @@ export const fetchGoogleCalendarEvents = async () => {
 	return items
 }
 
+// rearrange date
+export const getDate = (startDate) => {
+	const orderedDate = startDate.split('-')
+	return `${orderedDate[1]}/${orderedDate[2]}/${orderedDate[0]}`;
+}
+
 export interface EventOrganizer {
 	email: string
 	displayName: string

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -71,7 +71,6 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 
 		gtag('event', 'open_community_event_details')
 	})
-	console.log(calendarEventFragment)
 	return calendarEventFragment
 }
 

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -1,5 +1,5 @@
 import { h } from 'project:utils/html.ts'
-import { fetchGoogleCalendarEvents } from './home-community-events.constants.ts'
+import { fetchGoogleCalendarEvents, getDate } from './home-community-events.constants.ts'
 import { gtag } from 'project:utils/client/google-analytics.ts'
 
 /** Returns a string, empty if the value is nullish. */
@@ -11,24 +11,25 @@ const createCalendarEventFragment = (
 	event
 ) => withCalendarInteractiveBehavior(h(`<article class="p-community-event --closed">
 	<small class="p-community-event-date">
-		<span class="-date">${
-			new Date(event.start.date || event.start.dateTime).toLocaleString('en-US', {
-				day: '2-digit',
-				month: '2-digit',
-				year: 'numeric',
-			})
-		}</span>
-		${
-			event.start.dateTime
-				? `<span class="-time">${
-					new Date(event.start.dateTime).toLocaleString('en-US', {
-						hour: 'numeric',
-						minute: '2-digit',
-						timeZoneName: 'short'
-					})
-			}</span>`
-			: toString(event.start.date && `<span class="-time">All Day!</span>`)
-		}
+	<span class="-date">${event.start.date
+		? getDate(event.start.date)
+		: new Date(event.start.dateTime).toLocaleString('en-US', {
+			day: '2-digit',
+			month: '2-digit',
+			year: 'numeric'
+		})
+	}</span>
+	${
+		event.start.dateTime
+			? `<span class="-time">${
+				new Date(event.start.dateTime).toLocaleString('en-US', {
+					hour: 'numeric',
+					minute: '2-digit',
+					timeZoneName: 'short'
+				})
+		}</span>`
+		: toString(event.start.date && `<span class="-time">All Day!</span>`)
+	}
 	</small>
 	<hgroup class="p-community-event-heading">
 		<h5>${event.summary}</h5>
@@ -70,7 +71,7 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 
 		gtag('event', 'open_community_event_details')
 	})
-
+	console.log(calendarEventFragment)
 	return calendarEventFragment
 }
 


### PR DESCRIPTION
[ASTRO-5649](https://rocketcom.atlassian.net/browse/ASTRO-5649)

Google API sends all day events as just a date with no time zone info attached, so I had two add in a special exception to make them show the correct date in all time zones.