### PR TITLE
fix(events cal) update events calendar to handle all day and multi-day events

### DIFF
--- a/src/components/home/community/home-community-events.astro
+++ b/src/components/home/community/home-community-events.astro
@@ -1,7 +1,7 @@
 ---
 import { Sanitizer } from 'project:utils/sanitizer.js'
 import { For, When } from '@astropub/flow';
-import { fetchGoogleCalendarEvents, getDate } from './home-community-events.constants.js'
+import { fetchGoogleCalendarEvents, getDateRange } from './home-community-events.constants.js'
 import eventToggleHandler from './home-community-events.eventToggleHandler.js?url'
 
 /** Google Calendar Events. */
@@ -20,7 +20,7 @@ const sanitizer = new Sanitizer()
 				</hgroup>
 				<span class="p-community-event-info"> 
 					<small class="p-community-event-date">
-						<span class="-date">{calendarEvent.start.date ? getDate(calendarEvent.start.date)
+						<span class="-date">{calendarEvent.start.date ? getDateRange(calendarEvent.start.date, calendarEvent.end.date).dateRange
 
 							: new Date( calendarEvent.start.dateTime).toLocaleString('en-US', {
 								day: '2-digit',
@@ -40,7 +40,7 @@ const sanitizer = new Sanitizer()
 										})
 									}</span>
 								)
-							: <span class="-time">All Day!</span>
+							: getDateRange(calendarEvent.start.date, calendarEvent.end.date).singleDay ? <span class="-time">All Day!</span> : 
 							<Fragment />
 						}
 					</small>

--- a/src/components/home/community/home-community-events.astro
+++ b/src/components/home/community/home-community-events.astro
@@ -15,37 +15,41 @@ const sanitizer = new Sanitizer()
 	<div class="p-community-events-content">
 		<For of={calendarEvents}>{calendarEvent => (
 			<article class="p-community-event">
-				<small class="p-community-event-date">
-					<span class="-date">{calendarEvent.start.date ? getDate(calendarEvent.start.date)
-
-						: new Date( calendarEvent.start.dateTime).toLocaleString('en-US', {
-							day: '2-digit',
-							month: '2-digit',
-							year: 'numeric',
-							timeZone: 'PST'
-						})
-					}</span>
-					{
-						calendarEvent.start.dateTime
-							? (
-								<span class="-time">{
-									new Date(calendarEvent.start.dateTime).toLocaleString('en-US', {
-										hour: 'numeric',
-										minute: '2-digit',
-										timeZoneName: 'short'
-									})
-								}</span>
-							)
-						: <span class="-time">All Day!</span>
-						<Fragment />
-					}
-				</small>
 				<hgroup class="p-community-event-heading">
 					<h5>{calendarEvent.summary}</h5>
-					<When test={calendarEvent.location}>
-						<small class="p-community-event-subheading">{calendarEvent.location}</small>
-					</When>
 				</hgroup>
+				<span class="p-community-event-info"> 
+					<small class="p-community-event-date">
+						<span class="-date">{calendarEvent.start.date ? getDate(calendarEvent.start.date)
+
+							: new Date( calendarEvent.start.dateTime).toLocaleString('en-US', {
+								day: '2-digit',
+								month: '2-digit',
+								year: 'numeric',
+								timeZone: 'PST'
+							})
+						}</span>
+						{
+							calendarEvent.start.dateTime
+								? (
+									<span class="-time">{
+										new Date(calendarEvent.start.dateTime).toLocaleString('en-US', {
+											hour: 'numeric',
+											minute: '2-digit',
+											timeZoneName: 'short'
+										})
+									}</span>
+								)
+							: <span class="-time">All Day!</span>
+							<Fragment />
+						}
+					</small>
+					<When test={calendarEvent.location}>
+						<span class='-second-col'>
+							<span class="p-community-event-subheading">{calendarEvent.location}</span>
+						</span>
+					</When>
+				</span>
 				<span class="p-community-event-actions">
 					<button>View Details</button>
 				</span>

--- a/src/components/home/community/home-community-events.constants.ts
+++ b/src/components/home/community/home-community-events.constants.ts
@@ -32,10 +32,31 @@ export const fetchGoogleCalendarEvents = async () => {
 	return items
 }
 
-// rearrange date
-export const getDate = (startDate) => {
-	const orderedDate = startDate.split('-')
-	return `${orderedDate[1]}/${orderedDate[2]}/${orderedDate[0]}`;
+// rearrange date - Only triggers if the event is a google calendar All Day event.
+export const getDateRange = (startDate, endDate) => {
+	// get time difference in seconds
+	const eventLengthSec = (new Date(endDate).getTime() - new Date(startDate).getTime()) / 1000;
+	// convert day to seconds
+	const dayLength = 60 * 60 * 24;
+	// find event Lenth in days
+	const eventLength = eventLengthSec / dayLength
+
+	const orderedDateStart = startDate.split('-')
+
+	// if the event is more than one day long send back both dates
+	if (eventLength > 1) {
+		const orderedDateEnd = endDate.split('-')
+		return {
+			dateRange: `${orderedDateStart[1]}/${orderedDateStart[2]}/${orderedDateStart[0]} - ${orderedDateEnd[1]}/${orderedDateEnd[2]}/${orderedDateEnd[0]}`,
+			singleDay: false
+		}
+	} else {
+		// otherwise it is only one day so return just that date
+		return {
+			dateRange: `${orderedDateStart[1]}/${orderedDateStart[2]}/${orderedDateStart[0]}`,
+			singleDay: true
+		}
+	}
 }
 
 export interface EventOrganizer {

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -10,31 +10,35 @@ const createCalendarEventFragment = (
 	/** @type {CalendarEvent} */
 	event
 ) => withCalendarInteractiveBehavior(h(`<article class="p-community-event --closed">
-	<small class="p-community-event-date">
-	<span class="-date">${event.start.date
-		? getDate(event.start.date)
-		: new Date(event.start.dateTime).toLocaleString('en-US', {
-			day: '2-digit',
-			month: '2-digit',
-			year: 'numeric'
-		})
-	}</span>
-	${
-		event.start.dateTime
-			? `<span class="-time">${
-				new Date(event.start.dateTime).toLocaleString('en-US', {
-					hour: 'numeric',
-					minute: '2-digit',
-					timeZoneName: 'short'
-				})
-		}</span>`
-		: toString(event.start.date && `<span class="-time">All Day!</span>`)
-	}
-	</small>
 	<hgroup class="p-community-event-heading">
 		<h5>${event.summary}</h5>
-		${toString(event.location && `<small class="p-community-event-subheading">${event.location}</small>`)}
 	</hgroup>
+	<span class="p-community-event-info"> 
+		<small class="p-community-event-date">
+		<span class="-date">${event.start.date
+			? getDate(event.start.date)
+			: new Date(event.start.dateTime).toLocaleString('en-US', {
+				day: '2-digit',
+				month: '2-digit',
+				year: 'numeric'
+			})
+		}</span>
+		${
+			event.start.dateTime
+				? `<span class="-time">${
+					new Date(event.start.dateTime).toLocaleString('en-US', {
+						hour: 'numeric',
+						minute: '2-digit',
+						timeZoneName: 'short'
+					})
+			}</span>`
+			: toString(event.start.date && `<span class="-time">All Day!</span>`)
+		}
+	</small>
+	<span class='-second-col'>
+		${toString(event.location && `<span class="p-community-event-subheading">${event.location}</span>`)}
+	</span>
+		
 	<span class="p-community-event-actions">
 		<button>View Details</button>
 	</span>

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -32,7 +32,7 @@ const createCalendarEventFragment = (
 							timeZoneName: 'short'
 						})
 				}</span>`
-				: toString(getDateRange(event.start.date, event.end.date).singleDay && `<span class="-time">All Day!</span>`)
+				: toString(getDateRange(event.start.date, event.end.date).singleDay ? `<span class="-time">All Day!</span>` : '')
 			}
 		</small>
 		<span class='-second-col'>

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -15,28 +15,29 @@ const createCalendarEventFragment = (
 	</hgroup>
 	<span class="p-community-event-info"> 
 		<small class="p-community-event-date">
-		<span class="-date">${event.start.date
-			? getDate(event.start.date)
-			: new Date(event.start.dateTime).toLocaleString('en-US', {
-				day: '2-digit',
-				month: '2-digit',
-				year: 'numeric'
-			})
-		}</span>
-		${
-			event.start.dateTime
-				? `<span class="-time">${
-					new Date(event.start.dateTime).toLocaleString('en-US', {
-						hour: 'numeric',
-						minute: '2-digit',
-						timeZoneName: 'short'
-					})
-			}</span>`
-			: toString(event.start.date && `<span class="-time">All Day!</span>`)
-		}
-	</small>
-	<span class='-second-col'>
-		${toString(event.location && `<span class="p-community-event-subheading">${event.location}</span>`)}
+			<span class="-date">${event.start.date
+				? getDate(event.start.date)
+				: new Date(event.start.dateTime).toLocaleString('en-US', {
+					day: '2-digit',
+					month: '2-digit',
+					year: 'numeric'
+				})
+			}</span>
+			${
+				event.start.dateTime
+					? `<span class="-time">${
+						new Date(event.start.dateTime).toLocaleString('en-US', {
+							hour: 'numeric',
+							minute: '2-digit',
+							timeZoneName: 'short'
+						})
+				}</span>`
+				: toString(event.start.date && `<span class="-time">All Day!</span>`)
+			}
+		</small>
+		<span class='-second-col'>
+			${toString(event.location && `<span class="p-community-event-subheading">${event.location}</span>`)}
+		</span>
 	</span>
 		
 	<span class="p-community-event-actions">

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -1,5 +1,5 @@
 import { h } from 'project:utils/html.ts'
-import { fetchGoogleCalendarEvents, getDate } from './home-community-events.constants.ts'
+import { fetchGoogleCalendarEvents, getDateRange } from './home-community-events.constants.ts'
 import { gtag } from 'project:utils/client/google-analytics.ts'
 
 /** Returns a string, empty if the value is nullish. */
@@ -16,7 +16,7 @@ const createCalendarEventFragment = (
 	<span class="p-community-event-info"> 
 		<small class="p-community-event-date">
 			<span class="-date">${event.start.date
-				? getDate(event.start.date)
+				? getDateRange(event.start.date, event.end.date).dateRange
 				: new Date(event.start.dateTime).toLocaleString('en-US', {
 					day: '2-digit',
 					month: '2-digit',
@@ -32,7 +32,7 @@ const createCalendarEventFragment = (
 							timeZoneName: 'short'
 						})
 				}</span>`
-				: toString(event.start.date && `<span class="-time">All Day!</span>`)
+				: toString(getDateRange(event.start.date, event.end.date).singleDay && `<span class="-time">All Day!</span>`)
 			}
 		</small>
 		<span class='-second-col'>

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -270,7 +270,13 @@
 	grid-area: 3 / 1 / 4 / 5;
 	overflow: hidden;
 
+	/* Animation */
+	transition: margin 150ms;
+
 	@nest .p-community-event.--open & {
+		/* Layout */
+		margin-block-start: 5--step;
+
 		/* Animation */
 		animation: slideDown 150ms ease-out;
 	}

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -162,7 +162,7 @@
 	display: inline-block;
 
 	/* Layout */
-	min-width: 50--step;
+	min-width: 45--step;
 
 	/* Text */
 	font-size: 14--rpx;

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -122,29 +122,31 @@
 		/* Layout */
 		align-items: center;
 		grid-template-columns: repeat(5, 1fr);
-		grid-template-rows: repeat(2, 1fr);
+		grid-template-rows: repeat(2, auto);
 
 		&.--closed {
 			/* Layout */
 			gap: 0 2--step;
 		}
 
-		&.--open > *:nth-child(4) {
+		&.--open .p-community-event-subheading {
 			/* Layout */
-			margin-block-start: 20px;
+			display: block;
 		}
 	}
 
 	@media (width >= 1000px) {
 		/* Layout */
 		align-items: center;
-		gap: 5--step 10--step;
+		gap: 0 10--step;
+
+		/* Layout */
 		grid-template-columns: minmax(28--step, min-content) 1fr minmax(28--step, min-content);
 		grid-template-rows: auto auto;
 	}
 }
 
-.p-community-event-date, .p-community-event-heading {
+.p-community-event-heading {
 	/* Text */
 	font-size: 20--rpx;
 	font-weight: 500;
@@ -157,13 +159,17 @@
 }
 
 .p-community-event-date {
+	display: inline-block;
+
+	/* Layout */
+	min-width: 50--step;
+
+	/* Text */
+	font-size: 14--rpx;
+	font-weight: 500;
+	line-height: 22--rpx;
+
 	& .-time {
-		display: block;
-
-		/* Text */
-		font-size: 14--rpx;
-		line-height: calc(20 / 14);
-
 		/* Appearance */
 		color: var(--SecondaryColor);
 	}
@@ -176,34 +182,49 @@
 
 .p-community-event-heading {
 	/* Layout */
-	flex-grow: 1;
+	grid-area: 1/1/2/5;
+}
 
-	& small {
+.p-community-event-info {
+	display: flex;
+
+	/* Layout */
+	grid-area: 2/1/3/5;
+
+	& .-second-col {
+		display: inline-flex;
+
 		/* Layout */
-		/* stylelint-disable-next-line value-no-vendor-prefix */
-		display: -webkit-box;
-		-webkit-line-clamp: 1;
-		-webkit-box-orient: vertical;
-
-		/* Layout */
-		overflow: hidden;
-
-		/* Text */
-		font-size: 14--rpx;
-		line-height: calc(20 / 14);
-
-		/* Appearance */
-		color: var(--SecondaryColor);
+		flex-grow: 1;
 	}
 
 	@media (width < 1000px) {
-		/* Layout */
-		grid-area: 2 / 1 / 3 / 5;
-	}
+		display: initial;
 
-	@media (width < 1200px) {
 		/* Layout */
-		margin-block-start: 4--step;
+		margin-block-end: 2--step;
+	}
+}
+
+.p-community-event-subheading {
+
+	/* stylelint-disable-next-line value-no-vendor-prefix */
+	display: -webkit-box;
+	-webkit-line-clamp: 1;
+	-webkit-box-orient: vertical;
+
+	/* Layout */
+	overflow: hidden;
+
+	/* Text */
+	font-size: 14--rpx;
+	line-height: calc(20 / 14);
+
+	/* Appearance */
+	color: var(--SecondaryColor);
+
+	@nest .p-community-event.--open & {
+		display: block;
 	}
 }
 
@@ -212,7 +233,7 @@
 
 	/* Layout */
 	align-self: stretch;
-	grid-area: 1 / 3 / 3 / 3;
+	grid-area: 1 / 5 / 3 / 6;
 
 	@media (width < 1000px) {
 		/* Layout */
@@ -241,17 +262,12 @@
 			/* Appearance */
 			translate: 0 1px;
 		}
-
-		@media (width < 1200px) {
-			/* Layout */
-			margin-block-start: 4--step;
-		}
 	}
 }
 
 .p-community-event-details {
 	/* Layout */
-	grid-area: 2 / 2 / 2 / 3;
+	grid-area: 3 / 1 / 4 / 5;
 	overflow: hidden;
 
 	@nest .p-community-event.--open & {


### PR DESCRIPTION
[ASTRO-5682](https://rocketcom.atlassian.net/browse/ASTRO-5682)

**Problem:** The events calendar on the home page was not set up to handle events that span multiple days.

**Work:** In order to figure out how multi-date events might be displayed, I got together with Steve M. and Andrew. Steve created a new figma design which rearranged the events calendar information, making room for more date data.
I then:

- Implemented the new design
- Created some code so that start and end date of multi-day events would be displayed
- Set an exception for single day events where it would display the date and 'All Day'
- Tested both the JS and nonJS versions of this, as well as the server side and client side rendering.

Going to link the preview to Steve for Design review and tweak a few things.