### PR TITLE
Minor Layout Styling Fixes

### DIFF
--- a/src/components/home/articles/home-articles.css
+++ b/src/components/home/articles/home-articles.css
@@ -1,9 +1,10 @@
 .p-articles {
-	/* Layout */
-	inline-size: 100%;
+	display: flex;
 
 	/* Layout */
-	max-inline-size: 100%;
+	flex-flow: column;
+	gap: 4--step;
+	inline-size: 100%;
 
 	& .p-articles-content {
 		/* Layout */

--- a/src/components/home/banner/home-banner.astro
+++ b/src/components/home/banner/home-banner.astro
@@ -3,20 +3,19 @@ import type banner from 'project:data/home-banner.json'
 import Image from 'project:components/image/image'
 import './home-banner.css'
 
-const { data } = Astro.props as typeof banner
+const { ...props } = Astro.props as typeof banner['data']
 ---
-<span class="p-version">{data.version.data}</span>
 <header class="p-banner" role="banner">
 	<hgroup class="x-heading-group" role="group" aria-roledescription="Heading group">
 		<h2 class="x-heading">
-			<Image class="x-heading-image" {...data.image.data} />
+			<Image class="x-heading-image" {...props.image.data} />
 		</h2>
 		<p class="x-subheading" aria-roledescription="subtitle">
-			{data.subheading.data}
+			{props.subheading.data}
 		</p>
 	</hgroup>
 
 	<p class="x-content">
-		{data.content.data}
+		{props.content.data}
 	</p>
 </header>

--- a/src/components/home/banner/home-banner.css
+++ b/src/components/home/banner/home-banner.css
@@ -5,17 +5,15 @@
 	align-items: center;
 	flex-flow: column;
 	inline-size: min(100% - 4--step, 154--step);
-	padding-block: 7--step;
 
-	& .x-heading-group {
-		display: flex;
-
-		/* Layout */
-		align-items: center;
-		flex-flow: column;
+	& .x-heading-group,
+	& .x-heading {
+		display: contents;
 	}
 
 	& .x-heading-image {
+		display: inline-block;
+
 		/* Layout */
 		block-size: auto;
 		inline-size: min(100%, 72.5--step);
@@ -46,14 +44,4 @@
 		--text-shadow-blur: 6px;
 		--text-shadow-color: hsl(0 0% 0% / max(100% / 3));
 	}
-}
-
-.p-version {
-	/* Layout */
-	margin-block-end: 4--step;
-	margin-block-start: 4--step;
-	margin-inline-start: auto;
-
-	/* Text */
-	font-size: 14--rpx;
 }

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -5,6 +5,7 @@
 
 	/* Layout */
 	flex-flow: column;
+	gap: 4--step;
 	inline-size: 100%;
 
 	& .p-community-heading {
@@ -36,7 +37,6 @@
 
 .p-community-content {
 	/* Layout */
-	margin-block-start: 5--step;
 	padding-block: 5--step 7--step;
 	padding-inline: 5--step;
 
@@ -65,18 +65,17 @@
 	font-size: 24--rpx;
 	font-weight: 600;
 	line-height: calc(28 / 24);
-
-	& + * {
-		/* Layout */
-		margin-block-start: 4--step;
-	}
 }
 
 /* Community: Content: Events */
 
 .p-community-events {
+	display: flex;
+
 	/* Layout */
+	flex-flow: column;
 	flex-grow: 1;
+	gap: 4--step;
 }
 
 .p-community-events-content {
@@ -278,7 +277,11 @@
 /* Community: Content: Links */
 
 .p-community-links {
+	display: flex;
+
 	/* Layout */
+	flex-flow: column;
+	gap: 4--step;
 	margin-block-start: 10--step;
 
 	@media (width >= 1200px) {

--- a/src/components/home/explainer/home-explainer.css
+++ b/src/components/home/explainer/home-explainer.css
@@ -22,7 +22,6 @@
 
 	@media (width < 1520px) {
 		/* Layout */
-		margin-block-start: 8--step;
 		padding-block: 5--step;
 		padding-inline: 5--step;
 	}
@@ -30,7 +29,6 @@
 	@media (width >= 1520px) {
 		/* Layout */
 		gap: 20--step;
-		margin-block-start: 8--step;
 		padding-block: 9--step;
 		padding-inline: 17--step;
 	}

--- a/src/components/home/version/home-version.astro
+++ b/src/components/home/version/home-version.astro
@@ -1,0 +1,5 @@
+---
+import props from 'project:data/global.json'
+import './home-version.css'
+---
+<div class="p-version">Current version: {props.designSystem.version}</div>

--- a/src/components/home/version/home-version.css
+++ b/src/components/home/version/home-version.css
@@ -1,0 +1,8 @@
+.p-version {
+	/* Layout */
+	align-self: end;
+
+	/* Text */
+	font-size: 14--rpx;
+	line-height: calc(20 / 14);
+}

--- a/src/components/site-navigation/client/h-navigation-disclosure.css
+++ b/src/components/site-navigation/client/h-navigation-disclosure.css
@@ -61,7 +61,7 @@ svg {
 	}
 }
 
-::slotted(:is(a, span)) {
+:defined ::slotted(:is(a, span)) {
 	/* stylelint-disable-next-line declaration-no-important */
 	display: contents !important;
 }

--- a/src/components/site-navigation/site-navigation.css
+++ b/src/components/site-navigation/site-navigation.css
@@ -6,11 +6,10 @@
 	/* Layout */
 	align-items: center;
 	flex-flow: column;
+	inset-block-start: 0;
 	padding-block: 6--step;
-	z-index: 10;
-
-	/* Appearance */
-	background: var(--SurfaceColor);
+	position: sticky;
+	z-index: 1;
 
 	/* Animation */
 	transition: inline-size 200ms;
@@ -24,6 +23,38 @@
 		grid-template-rows: min-content 1fr; /* stylelint-disable-line */
 		padding-block: 2--step;
 		padding-inline: 9--step;
+	}
+
+	@media (width >= 800px) {
+		/* Layout */
+		block-size: min(100%, 100vh);
+		inline-size: 78--step;
+		overflow-x: hidden;
+		overflow-y: auto;
+		overflow-y: overlay;
+		scrollbar-width: none;
+
+		/* Masking */
+		mask-image: var(--mask);
+		mask-position: bottom;
+		mask-size: 100% 100%;
+
+		/* Behavior */
+		scroll-behavior: smooth;
+		scrollbar-gutter: stable;
+
+		/* Masking Reference */
+		--mask: linear-gradient(0deg, hsl(0 0% 0% / 0%) 0%, hsl(0 0% 0% / 100%) 12--step);
+
+		&::-webkit-scrollbar {
+			/* Layout */
+			width: 0;
+		}
+
+		&.-has-results {
+			/* Layout */
+			inline-size: min(50vw, 140--step);
+		}
 	}
 }
 
@@ -43,39 +74,6 @@
 	}
 }
 
-@media (width >= 800px) {
-	.p-navigation {
-		/* Layout */
-		block-size: min(100%, 100vh);
-		inline-size: 79--step;
-		inset-block-start: 0;
-		overflow-x: hidden;
-		overflow-y: auto;
-		overflow-y: overlay;
-		position: sticky;
-		scrollbar-width: none;
-
-		/* Masking */
-		mask-image: var(--mask);
-		mask-position: bottom;
-		mask-size: 100% 100%;
-
-		/* Behavior */
-		scroll-behavior: smooth;
-		scrollbar-gutter: stable;
-
-		&::-webkit-scrollbar {
-			/* Layout */
-			width: 0;
-		}
-
-		&.-has-results {
-			/* Layout */
-			inline-size: min(50vw, 140--step);
-		}
-	}
-}
-
 /* Navigation: Heading */
 
 .p-navigation-heading {
@@ -83,7 +81,11 @@
 		opacity: .75;
 	}
 
-	& :hover, :focus {
+	&:hover, &:focus {
+		@media (width >= 800px) {
+			outline-offset: 2--step;
+		}
+
 		& .logo-text {
 			opacity: 1;
 		}
@@ -118,6 +120,14 @@
 
 h-navigation-list {
 	display: contents;
+
+	&:not(:defined) {
+		display: block;
+
+		/* Layout */
+		grid-area: navigation;
+		margin-inline: -8--step;
+	}
 }
 
 .p-navigation ul {

--- a/src/components/site-skipto/site-skipto.astro
+++ b/src/components/site-skipto/site-skipto.astro
@@ -10,11 +10,12 @@ export interface Props {
 import './site-skipto.css'
 
 const {
+	slot,
 	url,
 	...attributes
 } = {
 	url: '#content',
 	...Astro.props
-}
+} as Props
 ---
 <a class="p-skip" {...attributes} href={url}><slot>Skip to main content</slot></a>

--- a/src/components/site-skipto/site-skipto.css
+++ b/src/components/site-skipto/site-skipto.css
@@ -1,4 +1,4 @@
-:where(.p-skip) {
+.p-skip {
 	display: flex;
 
 	/* Layout */
@@ -8,7 +8,7 @@
 	inset: 0;
 	justify-content: center;
 	position: fixed;
-	z-index: 1;
+	z-index: 2;
 
 	/* Text */
 	font-size: 18--rpx;

--- a/src/data/home-banner.json
+++ b/src/data/home-banner.json
@@ -2,10 +2,6 @@
 	"$schema": "./schema.json",
 	"type": "object",
 	"data": {
-		"version": {
-			"type": "text",
-			"data": "Current version: 7.0"
-		},
 		"heading": {
 			"type": "text",
 			"data": "Astro"

--- a/src/layouts/default/default-layout.astro
+++ b/src/layouts/default/default-layout.astro
@@ -17,13 +17,13 @@ const props = {
 	<slot slot="head" name="head" />
 	<meta slot="head" name="theme-color" content="#101923" />
 	<slot name="top" />
-	<div class="-side">
+	<div class="x-menu">
 		<SiteNavigation />
 	</div>
-	<div class="-main">
+	<div class="x-main" id="content">
 		<slot />
 	</div>
-	<div class="-foot">
+	<div class="x-foot">
 		<SiteFooter />
 	</div>
 </Document>

--- a/src/layouts/default/style/layout.css
+++ b/src/layouts/default/style/layout.css
@@ -1,8 +1,7 @@
 :where(html) {
 	/* Layout */
-	height: 100vh;
-	height: 100dvh;
-	overflow: auto scroll;
+	height: calc(100 * var(--vph));
+	width: calc(100 * var(--vpw));
 
 	/* Text */
 	font-family: "Helvetica", var(--SystemType);
@@ -15,36 +14,47 @@
 	scroll-behavior: smooth;
 	scrollbar-gutter: stable;
 	touch-action: manipulation;
+
+	/* Scroll Reference */
+	--sbh: calc(1vh - 1%);
+	--vph: calc(1vh - var(--sbh));
+	--sbw: calc(1vw - 1%);
+	--vpw: calc(1vw - var(--sbw));
 }
 
-@media (width >= 800px) {
-	.p-grid {
+:where(body) {
+	/* Layout */
+	margin: 0;
+}
+
+:where(.p-grid) {
+	/* Layout */
+	min-block-size: calc(100 * var(--vph));
+
+	@media (width >= 800px) {
 		display: grid;
 
 		/* Layout */
-		grid-template-columns: 79--step 1fr;
-		grid-template-rows: 1fr min-content;
+		grid-template: auto min-content / min-content auto;
+		grid-template-areas: "menu main" "foot foot";
+	}
 
-		& .-side {
-			/* Layout */
-			grid-column: 1 / 2;
-			grid-row: 1;
+	& .x-menu {
+		/* Layout */
+		grid-area: menu;
 
-			/* Appearance */
-			background-color: var(--SurfaceColor);
-			color: var(--PrimaryColor);
-		}
+		/* Appearance */
+		background: var(--SurfaceColor);
+		color: var(--PrimaryColor);
+	}
 
-		& .-main {
-			/* Layout */
-			grid-column: 2 / 3;
-			grid-row: 1;
-		}
+	& .x-main {
+		/* Layout */
+		grid-area: main;
+	}
 
-		& .-foot {
-			/* Layout */
-			grid-column: 1 / 3;
-			grid-row: 2;
-		}
+	& .x-foot {
+		/* Layout */
+		grid-area: foot;
 	}
 }

--- a/src/layouts/docs/docs-layout.astro
+++ b/src/layouts/docs/docs-layout.astro
@@ -33,7 +33,7 @@ const githubSourceURL = `${globalData.designSystem.repository}/tree/${globalData
 ---
 <Layout title={title} tabtitle={title}>
 	<SiteSkipTo slot="top" />
-	<main id="content">
+	<main>
 		<slot />
 		<ComplianceAside compliance={complianceData} />
 		<ContributionFooter sourceurl={githubSourceURL} />

--- a/src/layouts/docs/style/layout.css
+++ b/src/layouts/docs/style/layout.css
@@ -1,4 +1,4 @@
-.-main {
+.x-main {
 	/** Appearance */
 	background-color: var(--PrimaryColor);
 	color: var(--TextColor);

--- a/src/layouts/docs/style/layout.css
+++ b/src/layouts/docs/style/layout.css
@@ -1,5 +1,7 @@
-.x-main {
-	/** Appearance */
-	background-color: var(--PrimaryColor);
-	color: var(--TextColor);
+.p-grid {
+	& > .x-main {
+		/** Appearance */
+		background-color: var(--PrimaryColor);
+		color: var(--TextColor);
+	}
 }

--- a/src/layouts/home/home-layout.astro
+++ b/src/layouts/home/home-layout.astro
@@ -1,7 +1,9 @@
 ---
 import DefaultLayout from 'project:layouts/default/default-layout.astro'
+import SiteSkipto from 'project:components/site-skipto/site-skipto.astro';
 import './home-layout.css'
 ---
 <DefaultLayout>
+	<SiteSkipto slot="top" />
 	<slot />
 </DefaultLayout>

--- a/src/layouts/home/home-layout.css
+++ b/src/layouts/home/home-layout.css
@@ -1,11 +1,12 @@
-.-main {
+.p-grid > .x-main {
 	display: flex;
 
 	/* Layout */
 	align-items: center;
 	flex-flow: column;
+	gap: 14--step;
 	overflow: hidden;
-	padding-block-end: 18--step;
+	padding-block: 4--step 18--step;
 	padding-inline: max(4--step, 50% - 190--step);
 
 	/* Appearance */
@@ -16,19 +17,4 @@
 		url("/images/footer-bg-gradient.svg") no-repeat 50% 100% / 100% auto,
 		url("/images/footer-bg-noise.svg") no-repeat 50% 100% / 100% auto,
 		url("/images/footer-bg.webp") no-repeat 50% 100% / 100% auto;
-}
-
-:where(* + .p-community) {
-	/* Layout */
-	margin-block-start: 10--step;
-}
-
-:where(* + .p-articles) {
-	/* Layout */
-	margin-block-start: 10--step;
-}
-
-:where(* + .p-signup) {
-	/* Layout */
-	margin-block-start: 18--step;
 }

--- a/src/layouts/new-docs/style/layout.css
+++ b/src/layouts/new-docs/style/layout.css
@@ -1,5 +1,7 @@
-.-main {
-	/* Appearance */
-	background-color: var(--PrimaryColor);
-	color: var(--TextColor);
+.p-grid {
+	& > .x-main {
+		/* Appearance */
+		background-color: var(--PrimaryColor);
+		color: var(--TextColor);
+	}
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from 'project:layouts/home/home-layout.astro'
 
+import Version from 'project:components/home/version/home-version.astro'
+
 import Banner from 'project:components/home/banner/home-banner.astro'
 import banner from 'project:data/home-banner.json'
 
@@ -17,7 +19,8 @@ import Signup from 'project:components/home/signup/home-signup.astro'
 import signup from 'project:data/home-signup.json'
 ---
 <Layout>
-	<Banner data={banner.data} />
+	<Version />
+	<Banner {...banner.data} />
 	<Explainer data={explainer.data} />
 	<Community data={community.data} />
 	<Articles data={articles.data} />


### PR DESCRIPTION
<details><summary><strong>Fix partially hidden “Skip to Main Content” link</strong></summary><br />

When the “Skip to Main Content” link is focused, it is obscured on larger screens, making it harder to notice.

**Before**:
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/188426/220482719-fb1583e4-037a-4bed-ba2e-b2c9ba126236.png">

**After**
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/188426/220482525-162dd67f-0358-4a9b-8ed8-7fa4d88f7082.png">

Additionally, the “Skip to Main Content” link is missing from the homepage, which is restored.

---
</details>

<details><summary><strong>Fix missing styles for non-JS navigation on small screen widths</strong></summary><br />

If JS fails to load, our site navigation is open by default. On small screens, the fallback experience makes the home “Astro” link inaccessible, and displays the navigation in a way that is difficult to use when compared to the larger screen fallback experience.

**Before**:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/188426/220483313-cf6c7eea-51dc-48bd-b30f-c4bed0dcbfa2.png">

**After**:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/188426/220483367-3e7315b9-a9fb-4c3b-bbaa-ba895166f257.png">

---
</details>

<details><summary><strong>Fix missing active effect on “Astro” logo</strong></summary><br />

When the logo is focused, the brightening effect seen on hover is not applied on focus, and the outline wraps very tight.

**Before**:
<img width="310" alt="image" src="https://user-images.githubusercontent.com/188426/220482264-2d5d03e5-fe51-42e8-9bb8-72b74a60d38f.png">

**After**:
<img width="310" alt="image" src="https://user-images.githubusercontent.com/188426/220482321-95f388fe-26ea-4425-9cb1-fe696898174e.png">

---
</details>

<details><summary><strong>Fix spacing inconsistencies between navigation and main content</strong></summary><br />

When the “Current version” text was added to the homepage, it introduced a 21px line-height that differs from the 4px vertical rhythm used everywhere else on the website. This corrects that line-height.

The navigation menu is 316px wide (i.e. `79--step` wide) when it should be 312px wide (i.e. `78--step` wide) as seen in the ‘Astro Home no Screenshot’ frame in Figma.

Various margins and paddings are applied inconsistently throughout the homepage. Spacing is normalized using gaps.

**Before**:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/188426/220516560-fb1c6d7d-bc1d-4968-a055-80deddab3e31.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/188426/220516813-ab0e29e3-098e-40c2-84c0-c64118ada278.png">

**After**:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/188426/220516628-81d53ef8-a124-41b5-a1e5-f10a45bcec86.png">
<img width="401" alt="image" src="https://user-images.githubusercontent.com/188426/220516904-58a60228-e121-4d87-9f81-9a05e2a3a5bd.png">

---
</details>

<details><summary><strong>Restore masking effect at bottom of navigation</strong></summary><br />

The masking effect used to let visitors know the navigation continues disappeared as some point, tho most of the masking styles were still present. This adds the missing bits so that the masking is applied again.

**Before**:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/188426/220485166-5fb72c17-d5cd-46bb-9741-1b187eeba36c.png">

**After**:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/188426/220485218-12a82ade-408b-4e3c-888c-f588f5a414e5.png">

---
</details>

<details><summary><strong>Reuse existing data for AstroUXDS “Current Version” on the homepage</strong></summary><br />

The design system version is available from global data, so this removes the duplicate data added to the banner template. Also, this separates the code for the “version” (`.c-version`) component from the “banner” (`.c-banner`) component.

---
</details>