### PR TITLE
doc(breadcrumb) add deprecated to 7 item rule

### DIFF
--- a/src/data/compliance.json
+++ b/src/data/compliance.json
@@ -244,7 +244,7 @@
 						{
 							"numeral": 2,
 							"rule": "Breadcrumbs shall not extend past seven items.",
-							"status": "new",
+							"status": "deprecated",
 							"tier": 3
 						}
 					]


### PR DESCRIPTION
[Astro-5743](https://rocketcom.atlassian.net/browse/ASTRO-5743)

Added the Deprecated indicator to Breadcrumb compliance rule 3.7.2: Breadcrumb shall not extend beyond 7 items.