### PR TITLE
fix(compliance): fixed secondary button name

### DIFF
--- a/src/data/compliance.json
+++ b/src/data/compliance.json
@@ -304,7 +304,7 @@
 						},
 						{
 							"numeral": 8,
-							"rule": "Outline Button style shall indicate the less preferred option in grouped Buttons.",
+							"rule": "Secondary Button style shall indicate the less preferred option in grouped Buttons.",
 							"status": "under-review",
 							"tier": 2
 						},


### PR DESCRIPTION
Fixed name of Secondary Button in rule 4.1.8 from the old name (Outlined Button).