### PR TITLE
make show/hide event onclick entire event box

### DIFF
--- a/src/components/home/community/home-community-events.eventToggleHandler.js
+++ b/src/components/home/community/home-community-events.eventToggleHandler.js
@@ -18,7 +18,7 @@
 		//if you're clicking inside the event details don't activate close
 		if(event.target.closest('.p-community-event-details') !== null) return;
 
-		eventDetailsElement.style.setProperty('--content-height', eventDetailsElement.scrollHeight + 'px')
+		if(eventElement.classList.contains('--closed')) eventDetailsElement.style.setProperty('--content-height', eventDetailsElement.scrollHeight + 32 + 'px')
 
 		eventElement.classList.toggle('--closed')
 		eventElement.classList.toggle('--open')

--- a/src/components/home/community/home-community-events.eventToggleHandler.js
+++ b/src/components/home/community/home-community-events.eventToggleHandler.js
@@ -14,7 +14,7 @@
 	const eventDetailsToggle = eventElement.querySelector('.p-community-event-actions button')
 
 	// handle toggle events
-	eventDetailsToggle.addEventListener('click', event => {
+	eventElement.addEventListener('click', event => {
 		eventDetailsElement.style.setProperty('--content-height', eventDetailsElement.scrollHeight + 'px')
 
 		eventElement.classList.toggle('--closed')
@@ -24,7 +24,7 @@
 	})
 
 	// telemetry: user opens the community event details
-	eventDetailsToggle.addEventListener('click', () => {
+	eventElement.addEventListener('click', () => {
 		if (!eventElement.classList.contains('--open')) return
 
 		gtag('event', 'open_community_event_details')

--- a/src/components/home/community/home-community-events.eventToggleHandler.js
+++ b/src/components/home/community/home-community-events.eventToggleHandler.js
@@ -15,6 +15,8 @@
 
 	// handle toggle events
 	eventElement.addEventListener('click', event => {
+		if(event.target.nodeName === 'A') return;
+
 		eventDetailsElement.style.setProperty('--content-height', eventDetailsElement.scrollHeight + 'px')
 
 		eventElement.classList.toggle('--closed')
@@ -24,7 +26,9 @@
 	})
 
 	// telemetry: user opens the community event details
-	eventElement.addEventListener('click', () => {
+	eventElement.addEventListener('click', (event) => {
+		//don't activate if the target is a link
+		if(event.target.nodeName === 'A') return;
 		if (!eventElement.classList.contains('--open')) return
 
 		gtag('event', 'open_community_event_details')

--- a/src/components/home/community/home-community-events.eventToggleHandler.js
+++ b/src/components/home/community/home-community-events.eventToggleHandler.js
@@ -15,7 +15,8 @@
 
 	// handle toggle events
 	eventElement.addEventListener('click', event => {
-		if(event.target.nodeName === 'A') return;
+		//if you're clicking inside the event details don't activate close
+		if(event.target.closest('.p-community-event-details') !== null) return;
 
 		eventDetailsElement.style.setProperty('--content-height', eventDetailsElement.scrollHeight + 'px')
 
@@ -27,8 +28,8 @@
 
 	// telemetry: user opens the community event details
 	eventElement.addEventListener('click', (event) => {
-		//don't activate if the target is a link
-		if(event.target.nodeName === 'A') return;
+		//if you're clicking inside the event details don't activate close
+		if(event.target.closest('.p-community-event-details') !== null) return;
 		if (!eventElement.classList.contains('--open')) return
 
 		gtag('event', 'open_community_event_details')

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -62,6 +62,8 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 
 	// handle toggle events on the button
 	articleElement.addEventListener('click', event => {
+		//if you're clicking inside the event details don't activate close
+		if(event.target.closest('.p-community-event-details') !== null) return;
 
 		detailsElement.style.setProperty('--content-height', detailsElement.scrollHeight + 'px')
 
@@ -73,6 +75,8 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 
 	// telemetry: user opens the community event details
 	articleElement.addEventListener('click', (event) => {
+		//if you're clicking inside the event details don't activate close
+		if(event.target.closest('.p-community-event-details') !== null) return;
 		if (!articleElement.classList.contains('--open')) return
 
 		gtag('event', 'open_community_event_details')

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -62,8 +62,6 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 
 	// handle toggle events on the button
 	articleElement.addEventListener('click', event => {
-		//don't activate if the target is a link
-		if(event.target.nodeName === 'A') return;
 
 		detailsElement.style.setProperty('--content-height', detailsElement.scrollHeight + 'px')
 
@@ -75,8 +73,6 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 
 	// telemetry: user opens the community event details
 	articleElement.addEventListener('click', (event) => {
-		//don't activate if the target is a link
-		if(event.target.nodeName === 'A') return;
 		if (!articleElement.classList.contains('--open')) return
 
 		gtag('event', 'open_community_event_details')

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -61,7 +61,7 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 	const actionsElement = /** @type {HTMLElement} */ (calendarEventFragment.querySelector('.p-community-event-actions button'))
 
 	// handle toggle events on the button
-	actionsElement.addEventListener('click', event => {
+	articleElement.addEventListener('click', event => {
 		detailsElement.style.setProperty('--content-height', detailsElement.scrollHeight + 'px')
 
 		articleElement.classList.toggle('--closed')
@@ -71,7 +71,7 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 	})
 
 	// telemetry: user opens the community event details
-	actionsElement.addEventListener('click', () => {
+	articleElement.addEventListener('click', () => {
 		if (!articleElement.classList.contains('--open')) return
 
 		gtag('event', 'open_community_event_details')

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -62,6 +62,9 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 
 	// handle toggle events on the button
 	articleElement.addEventListener('click', event => {
+		//don't activate if the target is a link
+		if(event.target.nodeName === 'A') return;
+
 		detailsElement.style.setProperty('--content-height', detailsElement.scrollHeight + 'px')
 
 		articleElement.classList.toggle('--closed')
@@ -71,7 +74,9 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 	})
 
 	// telemetry: user opens the community event details
-	articleElement.addEventListener('click', () => {
+	articleElement.addEventListener('click', (event) => {
+		//don't activate if the target is a link
+		if(event.target.nodeName === 'A') return;
 		if (!articleElement.classList.contains('--open')) return
 
 		gtag('event', 'open_community_event_details')

--- a/src/components/home/community/home-community-events.update.js
+++ b/src/components/home/community/home-community-events.update.js
@@ -65,7 +65,7 @@ const withCalendarInteractiveBehavior = (/** @type {HTMLElement} */ calendarEven
 		//if you're clicking inside the event details don't activate close
 		if(event.target.closest('.p-community-event-details') !== null) return;
 
-		detailsElement.style.setProperty('--content-height', detailsElement.scrollHeight + 'px')
+		if(articleElement.classList.contains('--closed')) detailsElement.style.setProperty('--content-height', detailsElement.scrollHeight + 32 + 'px')
 
 		articleElement.classList.toggle('--closed')
 		articleElement.classList.toggle('--open')

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -271,6 +271,9 @@
 	grid-area: 3 / 1 / 4 / 5;
 	overflow: hidden;
 
+	/* Appearance */
+	cursor: initial;
+
 	/* Animation */
 	transition: margin 150ms;
 

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -92,7 +92,6 @@
 
 	/* Layout */
 	padding-block: 3--step;
-	padding-inline: 5--step;
 	position: relative;
 
 	/* Appearance */
@@ -115,6 +114,9 @@
 	}
 
 	&.--open {
+		/* Layout */
+		padding-block-end: 0--step;
+
 		/* Animation */
 		transition: gap 150ms;
 	}
@@ -148,6 +150,9 @@
 }
 
 .p-community-event-heading {
+	/* Layout */
+	padding-inline-start: 5--step;
+
 	/* Text */
 	font-size: 20--rpx;
 	font-weight: 500;
@@ -191,6 +196,7 @@
 
 	/* Layout */
 	grid-area: 2/1/3/5;
+	margin-inline-start: 5--step;
 
 	& .-second-col {
 		display: inline-flex;
@@ -235,11 +241,7 @@
 	/* Layout */
 	align-self: stretch;
 	grid-area: 1 / 5 / 3 / 6;
-
-	@media (width < 1000px) {
-		/* Layout */
-		grid-area: 1 / 5 / 2 / 6;
-	}
+	padding-inline-end: 5--step;
 
 	& button {
 		display: flex;
@@ -268,18 +270,20 @@
 
 .p-community-event-details {
 	/* Layout */
-	grid-area: 3 / 1 / 4 / 5;
+	grid-area: 3 / 1 / 4 / 6;
 	overflow: hidden;
+	padding-inline: 5--step;
 
 	/* Appearance */
 	cursor: initial;
 
 	/* Animation */
-	transition: margin 150ms;
+	transition: padding 150ms;
 
 	@nest .p-community-event.--open & {
 		/* Layout */
-		margin-block-start: 5--step;
+		padding-block-end: 3--step;
+		padding-block-start: 5--step;
 
 		/* Animation */
 		animation: slideDown 150ms ease-out;
@@ -288,16 +292,10 @@
 	@nest .p-community-event.--closed & {
 		/* Layout */
 		height: 0;
-		visibility: none;
+		visibility: hidden;
 
 		/* Animation */
 		animation: slideUp 150ms ease-out;
-	}
-
-	@media (width < 1000px) {
-		/* Layout */
-		grid-area: 3 / 1 / 4 / 6;
-		overflow: hidden;
 	}
 }
 

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -93,6 +93,7 @@
 	/* Layout */
 	padding-block: 3--step;
 	padding-inline: 5--step;
+	position: relative;
 
 	/* Appearance */
 	background: var(--SurfaceSelectedColor);
@@ -105,6 +106,7 @@
 	&:is(:hover, :focus-visible) {
 		/* Appearance */
 		background: var(--InteractiveMutedColor);
+		cursor: pointer;
 	}
 
 	&.--closed {

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -285,14 +285,21 @@
 		padding-block-end: 3--step;
 		padding-block-start: 5--step;
 
+		/* Appearance */
+		opacity: 1;
+
 		/* Animation */
 		animation: slideDown 150ms ease-out;
+		transition: visibility 0s linear 0s, opacity 300ms;
 	}
 
 	@nest .p-community-event.--closed & {
 		/* Layout */
 		height: 0;
 		visibility: hidden;
+
+		/* Appearance */
+		opacity: 0;
 
 		/* Animation */
 		animation: slideUp 150ms ease-out;


### PR DESCRIPTION
On the home page I made the entire event box interactive.
[ASTRO-5827](https://rocketcom.atlassian.net/browse/ASTRO-5827)

I checked keyboard controls and they still function as one would expect. Also, links in the event details area still supersede the on click functionality so they can be clicked.