### PR TITLE
docs(specs) update image sizes to better match figma

### DIFF
--- a/src/layouts/new-docs/style/specs.css
+++ b/src/layouts/new-docs/style/specs.css
@@ -48,6 +48,11 @@
 		justify-content: space-evenly;
 		min-block-size: 81--step;
 
+		@media (width < 768px) {
+			/* Layout */
+			padding-inline: 0;
+		}
+
 		& figure {
 			/* Layout */
 			margin-block-end: 0;

--- a/src/layouts/new-docs/style/specs.css
+++ b/src/layouts/new-docs/style/specs.css
@@ -5,7 +5,6 @@
 	flex-flow: column;
 	gap: 10--rpx;
 	margin-block-end: 5--step;
-	min-block-size: 81--step;
 	padding: 5--step;
 
 	/* Appearance */
@@ -29,6 +28,9 @@
 		}
 
 		& ol {
+			/* Layout */
+			margin-block-end: 0;
+
 			/* Appearance */
 			color: var(--PrimaryColor);
 
@@ -44,9 +46,13 @@
 		align-content: space-evenly;
 		flex-flow: row wrap;
 		justify-content: space-evenly;
+		min-block-size: 81--step;
 
-		@media (width <= 375px) {
-			& figure {
+		& figure {
+			/* Layout */
+			margin-block-end: 0;
+
+			@media (width < 768px) {
 				/* Layout */
 				inline-size: 100%;
 

--- a/src/pages/components/button/specs.md
+++ b/src/pages/components/button/specs.md
@@ -87,9 +87,9 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ### Secondary
 
 <div class="spec-container -examples">
-    <figure><img loading="lazy" width="139" src="/img/components/button/button-secondary-medium-default.png" alt="Default Secondary Button"/></figure>
-    <figure><img loading="lazy" width="139" src="/img/components/button/button-secondary-medium-hover.png" alt="Secondary Button with Hover State"/></figure>
-    <figure><img loading="lazy" width="139" src="/img/components/button/button-secondary-medium-disabled.png" alt="Disabled Secondary Button"/></figure>
+    <figure><img loading="lazy" width="163" src="/img/components/button/button-secondary-medium-default.png" alt="Default Secondary Button"/></figure>
+    <figure><img loading="lazy" width="163" src="/img/components/button/button-secondary-medium-hover.png" alt="Secondary Button with Hover State"/></figure>
+    <figure><img loading="lazy" width="163" src="/img/components/button/button-secondary-medium-disabled.png" alt="Disabled Secondary Button"/></figure>
 </div>
 
 #### Default

--- a/src/pages/components/button/specs.md
+++ b/src/pages/components/button/specs.md
@@ -6,7 +6,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ## Anatomy
 
 <div class="spec-container -anatomy">
-    <figure><img loading="lazy" width="350px" src="/img/components/button/button-anatomy.png" alt="Anatomy Image"/></figure>
+    <figure><img loading="lazy" width="260px" src="/img/components/button/button-anatomy.png" alt="Anatomy Image"/></figure>
     <ol>
         <li>Container</li>
         <li>Left icon (optional) (optional)</li>
@@ -20,8 +20,8 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 | Attribute                                            | Token                                   | Value                                                                                                                 |
 |:-----------------------------------------------------|:----------------------------------------|:----------------------------------------------------------------------------------------------------------------------|
 | <span class="attr-title">Container</span>            |                                         |                                                                                                                       |
-| Padding (left and right)                             | button-padding-x-medium                 | 1rem                                                                                                                |
-| Padding (top and bottom)                             | button-padding-y-medium                 | 0.5rem                                                                                                                  |
+| Padding (left and right)                             | button-padding-x-medium                 | 1rem                                                                                                                  |
+| Padding (top and bottom)                             | button-padding-y-medium                 | 0.5rem                                                                                                                |
 | Border width                                         | button-border-width                     | 1px                                                                                                                   |
 | Border radius                                        | button-radius                           | 3px                                                                                                                   |
 | Border color                                         | button-color-border-primary-default     | #4dacff                                                                                                               |
@@ -57,7 +57,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 |:-----------------------------------------------------|:----------------------------------------|:--------|
 | <span class="attr-title">Container</span>            |                                         |         |
 | Background color                                     | button-color-background-primary-default | #4dacff |
-| Border color                                         | button-color-border-primary-default | #4dacff |
+| Border color                                         | button-color-border-primary-default     | #4dacff |
 | <span class="attr-title">Label</span>                |                                         |         |
 | Text color                                           | button-color-text-primary               | #080c11 |
 | <span class="attr-title">Left icon (optional)</span> |                                         |         |
@@ -72,7 +72,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 |:------------------------------------------|:--------------------------------------|:--------|
 | <span class="attr-title">Container</span> |                                       |         |
 | Background color                          | button-color-background-primary-hover | #92cbff |
-| Border color                          | button-color-border-primary-hover | #92cbff |
+| Border color                              | button-color-border-primary-hover     | #92cbff |
 :::
 
 #### Disabled
@@ -100,7 +100,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 |:-----------------------------------------------------|:-----------------------------------------|:----------|
 | <span class="attr-title">Container</span>            |                                          |           |
 | Background color                                     | button-color-background-secondary        | #ffffff00 |
-| Border color                                     | button-color-border-secondary-default        | #ffffff00 |
+| Border color                                         | button-color-border-secondary-default    | #ffffff00 |
 | <span class="attr-title">Label</span>                |                                          |           |
 | Text color                                           | button-color-text-secondary-default      | #4dacff   |
 | <span class="attr-title">Left icon (optional)</span> |                                          |           |
@@ -115,7 +115,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 |:-----------------------------------------------------|:---------------------------------------|:----------|
 | <span class="attr-title">Container</span>            |                                        |           |
 | Background color                                     | button-color-background-secondary      | #ffffff00 |
-| Border color                                     | button-color-border-secondary-hover      | #ffffff00 |
+| Border color                                         | button-color-border-secondary-hover    | #ffffff00 |
 | <span class="attr-title">Label</span>                |                                        |           |
 | Text color                                           | button-color-text-secondary-hover      | #92cbff   |
 | <span class="attr-title">Left icon (optional)</span> |                                        |           |
@@ -134,9 +134,9 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ### Borderless
 
 <div class="spec-container -examples">
-    <figure><img loading="lazy" width="145" src="/img/components/button/button-borderless-default.png" alt="Default Borderless Button"/></figure>
-    <figure><img loading="lazy" width="145" src="/img/components/button/button-borderless-hover.png" alt="Borderless Button with Hover State"/></figure>
-    <figure><img loading="lazy" width="145" src="/img/components/button/button-borderless-disabled.png" alt="Disabled Borderless Button"/></figure>
+    <figure><img loading="lazy" width="161" src="/img/components/button/button-borderless-default.png" alt="Default Borderless Button"/></figure>
+    <figure><img loading="lazy" width="161" src="/img/components/button/button-borderless-hover.png" alt="Borderless Button with Hover State"/></figure>
+    <figure><img loading="lazy" width="161" src="/img/components/button/button-borderless-disabled.png" alt="Disabled Borderless Button"/></figure>
 </div>
 
 #### Default
@@ -187,8 +187,8 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 | Attribute                                 | Token                  | Value   |
 |:------------------------------------------|:-----------------------|:--------|
 | <span class="attr-title">Container</span> |                        |         |
-| Padding (left and right)                  | button-padding-x-small | 1rem |
-| Padding (top and bottom)                  | button-padding-y-small | 0.25rem    |
+| Padding (left and right)                  | button-padding-x-small | 1rem    |
+| Padding (top and bottom)                  | button-padding-y-small | 0.25rem |
 :::
 
 ### Medium
@@ -197,8 +197,8 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 | Attribute                                 | Token                   | Value  |
 |:------------------------------------------|:------------------------|:-------|
 | <span class="attr-title">Container</span> |                         |        |
-| Padding (left and right)                  | button-padding-x-medium | 1rem |
-| Padding (top and bottom)                  | button-padding-y-medium | 0.5rem   |
+| Padding (left and right)                  | button-padding-x-medium | 1rem   |
+| Padding (top and bottom)                  | button-padding-y-medium | 0.5rem |
 :::
 
 ### Large
@@ -207,8 +207,8 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 | Attribute                                 | Token                  | Value   |
 |:------------------------------------------|:-----------------------|:--------|
 | <span class="attr-title">Container</span> |                        |         |
-| Padding (left and right)                  | button-padding-x-large | 1rem |
-| Padding (top and bottom)                  | button-padding-y-large | 0.75rem    |
+| Padding (left and right)                  | button-padding-x-large | 1rem    |
+| Padding (top and bottom)                  | button-padding-y-large | 0.75rem |
 :::
 
 ## Icon Only

--- a/src/pages/components/input-field/specs.md
+++ b/src/pages/components/input-field/specs.md
@@ -9,7 +9,7 @@ git: rux-input
 ## Anatomy
 
 <div class="spec-container -anatomy">
-    <figure><img loading="lazy" width="270px" src="/img/components/input-field/input-anatomy.png" alt="Anatomy Image"/></figure>
+    <figure><img loading="lazy" width="252px" src="/img/components/input-field/input-anatomy.png" alt="Anatomy Image"/></figure>
     <ol>
         <li>Container</li>
         <li>Prefix Slot (optional)</li>

--- a/src/pages/components/select/specs.md
+++ b/src/pages/components/select/specs.md
@@ -7,7 +7,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ## Anatomy
 
 <div class="spec-container -anatomy">
-    <figure><img loading="lazy" width="270px" src="/img/components/select/select-anatomy.png" alt="Anatomy Image"/></figure>
+    <figure><img loading="lazy" width="226px" src="/img/components/select/select-anatomy.png" alt="Anatomy Image"/></figure>
     <ol>
         <li>Container</li>
         <li>Text</li>

--- a/src/pages/components/slider/specs.md
+++ b/src/pages/components/slider/specs.md
@@ -7,7 +7,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ## Anatomy
 
 <div class="spec-container -anatomy">
-    <figure><img loading="lazy" width="350px" src="/img/components/slider/slider-anatomy.png" alt="Anatomy Image"/></figure>
+    <figure><img loading="lazy" width="384px" src="/img/components/slider/slider-anatomy.png" alt="Anatomy Image"/></figure>
     <ol>
         <li>Thumb</li>
         <li>Track (active)</li>

--- a/src/pages/components/textarea/specs.md
+++ b/src/pages/components/textarea/specs.md
@@ -7,7 +7,7 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ## Anatomy
 
 <div class="spec-container -anatomy">
-    <figure><img loading="lazy" width="270px" src="/img/components/textarea/textarea-anatomy.png" alt="Anatomy Image"/></figure>
+    <figure><img loading="lazy" width="226px" src="/img/components/textarea/textarea-anatomy.png" alt="Anatomy Image"/></figure>
     <ol>
         <li>Container</li>
         <li>Input text</li>
@@ -20,19 +20,19 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 | Attribute                                 | Token                              | Value                                                                                                                 |
 |:------------------------------------------|:-----------------------------------|:----------------------------------------------------------------------------------------------------------------------|
 | <span class="attr-title">Container</span> |                                    |                                                                                                                       |
-| Padding (left and right)                  | textarea-padding-x-medium             | 0.5rem                                                                                                                |
-| Padding (top and bottom)                  | textarea-padding-y-medium             | 0.5rem                                                                                                                |
-| Border width                              | textarea-border-width                 | 1px                                                                                                                   |
-| Border radius                             | textarea-radius                       | 3px                                                                                                                   |
-| Border color                              | textarea-color-border-default         | #2b659b                                                                                                               |
-| Background color                          | textarea-color-background-default     | #101923                                                                                                               |
+| Padding (left and right)                  | textarea-padding-x-medium          | 0.5rem                                                                                                                |
+| Padding (top and bottom)                  | textarea-padding-y-medium          | 0.5rem                                                                                                                |
+| Border width                              | textarea-border-width              | 1px                                                                                                                   |
+| Border radius                             | textarea-radius                    | 3px                                                                                                                   |
+| Border color                              | textarea-color-border-default      | #2b659b                                                                                                               |
+| Background color                          | textarea-color-background-default  | #101923                                                                                                               |
 | <span class="attr-title">Label</span>     |                                    |                                                                                                                       |
 | Font family                               | font-control-body-1-font-family    | 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif |
 | Font size                                 | font-control-body-1-font-size      | 1rem                                                                                                                  |
 | Font weight                               | font-control-body-1-font-weight    | 400                                                                                                                   |
 | Line height                               | font-control-body-1-line-height    | calc(20 / 16)                                                                                                         |
 | Letter spacing                            | font-control-body-1-letter-spacing | 0.005em                                                                                                               |
-| Text color                                | textarea-color-text-default           | #ffffff                                                                                                               |
+| Text color                                | textarea-color-text-default        | #ffffff                                                                                                               |
 :::
 
 ## States
@@ -48,27 +48,27 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ### Default
 
 :::specs-table-container
-| Attribute                                 | Token                    | Value   |
-|:------------------------------------------|:-------------------------|:--------|
-| <span class="attr-title">Container</span> |                          |         |
+| Attribute                                 | Token                         | Value   |
+|:------------------------------------------|:------------------------------|:--------|
+| <span class="attr-title">Container</span> |                               |         |
 | Border color                              | textarea-color-border-default | #2b659b |
 :::
 
 ### Hover
 
 :::specs-table-container
-| Attribute                                 | Token                    | Value   |
-|:------------------------------------------|:-------------------------|:--------|
-| <span class="attr-title">Container</span> |                          |         |
+| Attribute                                 | Token                       | Value   |
+|:------------------------------------------|:----------------------------|:--------|
+| <span class="attr-title">Container</span> |                             |         |
 | Border color                              | textarea-color-border-hover | #92cbff |
 :::
 
 ### Invalid
 
 :::specs-table-container
-| Attribute                                 | Token                      | Value   |
-|:------------------------------------------|:---------------------------|:--------|
-| <span class="attr-title">Container</span> |                            |         |
+| Attribute                                 | Token                         | Value   |
+|:------------------------------------------|:------------------------------|:--------|
+| <span class="attr-title">Container</span> |                               |         |
 | Border color                              | textarea-color-border-invalid | #ff3838 |
 :::
 
@@ -102,31 +102,31 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ### Small
 
 :::specs-table-container
-| Attribute                                 | Token                 | Value   |
-|:------------------------------------------|:----------------------|:--------|
-| <span class="attr-title">Container</span> |                       |         |
-| Padding (left and right)                      | textarea-padding-x-small | 0.5rem  |
-| Padding (top and bottom)                      | textarea-padding-y-small | 0.25rem |
+| Attribute                                 | Token                    | Value   |
+|:------------------------------------------|:-------------------------|:--------|
+| <span class="attr-title">Container</span> |                          |         |
+| Padding (left and right)                  | textarea-padding-x-small | 0.5rem  |
+| Padding (top and bottom)                  | textarea-padding-y-small | 0.25rem |
 :::
 
 ### Medium
 
 :::specs-table-container
-| Attribute                                 | Token                 | Value   |
-|:------------------------------------------|:----------------------|:--------|
-| <span class="attr-title">Container</span> |                       |         |
-| Padding (left and right)                      | textarea-padding-x-medium | 0.5rem  |
-| Padding (top and bottom)                      | textarea-padding-y-medium | 0.5rem |
+| Attribute                                 | Token                     | Value  |
+|:------------------------------------------|:--------------------------|:-------|
+| <span class="attr-title">Container</span> |                           |        |
+| Padding (left and right)                  | textarea-padding-x-medium | 0.5rem |
+| Padding (top and bottom)                  | textarea-padding-y-medium | 0.5rem |
 :::
 
 ### Large
 
 :::specs-table-container
-| Attribute                                 | Token                 | Value   |
-|:------------------------------------------|:----------------------|:--------|
-| <span class="attr-title">Container</span> |                       |         |
-| Padding (left and right)                      | textarea-padding-x-large | 0.5rem  |
-| Padding (top and bottom)                      | textarea-padding-y-large | 0.75rem |
+| Attribute                                 | Token                    | Value   |
+|:------------------------------------------|:-------------------------|:--------|
+| <span class="attr-title">Container</span> |                          |         |
+| Padding (left and right)                  | textarea-padding-x-large | 0.5rem  |
+| Padding (top and bottom)                  | textarea-padding-y-large | 0.75rem |
 :::
 
 ## Variants
@@ -138,8 +138,8 @@ layout: project:layouts/component-docs/component-docs-layout.astro
 ### Placeholder Text
 
 :::specs-table-container
-| Attribute                                 | Token                        | Value   |
-|:------------------------------------------|:-----------------------------|:--------|
-| <span class="attr-title">Container</span> |                              |         |
+| Attribute                                 | Token                           | Value   |
+|:------------------------------------------|:--------------------------------|:--------|
+| <span class="attr-title">Container</span> |                                 |         |
 | Text color                                | textarea-color-text-placeholder | #a4abb6 |
 :::


### PR DESCRIPTION
[Astro-5998](https://rocketcom.atlassian.net/browse/ASTRO-5998)

Verify the sizes between figma and spec pages for images. Also a couple of css changes to allow the example images to respond at a higher screen width.