### PR TITLE
Fixing icon size and where the search sticks on mobile.

### DIFF
--- a/src/components/icon-search/icon-search.css
+++ b/src/components/icon-search/icon-search.css
@@ -109,6 +109,9 @@
 
 			&:is(figure) {
 				/* Layout */
+				inline-size: 100%;
+
+				/* Layout */
 				margin-block: 1--step;
 			}
 

--- a/src/layouts/new-docs/style/page.css
+++ b/src/layouts/new-docs/style/page.css
@@ -221,6 +221,11 @@
 	/* Layout */
 	inset-block-start: 0;
 	position: sticky;
+
+	@media (width < 1024px) {
+		/* Layout */
+		inset-block-start: 60--rpx;
+	}
 }
 
 .page-content {


### PR DESCRIPTION
This PR fixes the issue where the icons in the icon library were not respecting the min-width, and the icon search bar was hidden under the nav bar because it is now sticky.