### PR TITLE
Fix feedback widget height on small height devices

### DIFF
--- a/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
+++ b/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
@@ -95,12 +95,9 @@
 	& .widget_content-wrapper {
 		/* Layout */
 		block-size: auto;
-
-		/* Layout */
 		inline-size: 75--step;
-
-		/* Layout */
-		overflow: hidden;
+		max-block-size: calc(100dvh - 15--step);
+		overflow-y: auto;
 		padding-block: 5--step;
 		padding-inline: 3--step;
 		position: relative;


### PR DESCRIPTION
This change updates the height on the feedback widget so that it cannot exceed the height of the page minus the space required for the site navigation on small-width devices.