### PR TITLE
Update all Markdown tables to use overflow fix

### DIFF
--- a/src/pages/components/classification-markings.md
+++ b/src/pages/components/classification-markings.md
@@ -38,7 +38,7 @@ The guidance on this page is focused on the use of, and rules for, Classificatio
 
 ### Banner Examples
 
-:::specs-table-container
+:::table-overflow
 |                                                                              | State            | Hex Value | RGB Value    | CSS                                                     | Font Color |
 |------------------------------------------------------------------------------|------------------|-----------|--------------|---------------------------------------------------------|------------|
 | ![Marking Unclassified Swatch](/img/swatches/marking__unclassified.svg)      | Unclassified     | #007a33   | 0, 122, 51   | `--classification-banner-color-background-unclassified` | white      |
@@ -135,7 +135,7 @@ The colors used in the Tag components are the same as those in the Overall Banne
 
 Whenever classified or controlled information is present, use an Authority Block, to trace the source of the designation and any necessary clarifications about declassification dates or classification reasons. The Authority Block is typically in the bottom left of a document page, but can be placed elsewhere according to layout needs. Similarly, if necessary in the layout, the authority information for electronic material may appear as a single line of text instead of the typical three-line approach. Note that there is a slightly different structure for CUI, originally classified documents, and documents with a classification derived from another document. Authority Blocks are most often displayed as lines of text and do not currently require a component to satisfy this marking requirement. To learn more about this element, go to our [Additional Resources](#additional-resources).
 
-:::specs-table-container
+:::table-overflow
 | **Do**                                                                                                           |
 |------------------------------------------------------------------------------------------------------------------|
 | Show the source of classified or controlled information on a page with relevant contact information.             |

--- a/src/pages/components/status-symbol.md
+++ b/src/pages/components/status-symbol.md
@@ -36,7 +36,7 @@ Status colors are provided for both light and dark theme versions of Astro in He
 
 ### Dark Theme Status Colors
 
-:::specs-table-container
+:::table-overflow
 |                                                              | Hex     | RGB         | CSS                                           | Synonyms                                       |  |
 |--------------------------------------------------------------|---------|-------------|-----------------------------------------------|------------------------------------------------|--|
 | ![Status Color: Critical ](/img/swatches/critical__dark.svg) | #ff3838 | 255,56,56   | `--status-symbol-color-fill-critical-on-dark` | Critical, form error, alert, emergency, urgent |  |
@@ -49,7 +49,7 @@ Status colors are provided for both light and dark theme versions of Astro in He
 
 ### Light Theme Status Colors
 
-:::specs-table-container
+:::table-overflow
 |                                                               | Hex     | RGB         | CSS                                            | Synonyms                                       |  |
 |---------------------------------------------------------------|---------|-------------|------------------------------------------------|------------------------------------------------|--|
 | ![Status Color: Critical ](/img/swatches/critical__light.svg) | #ff2a04 | 255,42,4    | `--status-symbol-color-fill-critical-on-light` | Critical, form error, alert, emergency, urgent |  |
@@ -64,7 +64,7 @@ Status colors are provided for both light and dark theme versions of Astro in He
 
 - In light theme Status Symbols should have a 1px border set to the inside of the symbol.
 
-:::specs-table-container
+:::table-overflow
 |                                                                      | Hex     | RGB       | CSS                                     | Synonyms                                 |  |
 |----------------------------------------------------------------------|---------|-----------|-----------------------------------------|------------------------------------------|--|
 | ![Status Color: Critical ](/img/swatches/critical-border__light.svg) | #661102 | 102,17,2  | `--status-symbol-color-border-critical` | Critical, alert, emergency, urgent       |  |

--- a/src/pages/design-guidelines/color.md
+++ b/src/pages/design-guidelines/color.md
@@ -56,7 +56,7 @@ All color pairings should follow the latest WCAG AA contrast rules. Astro compon
 
 ### Primary Palette
 
-:::specs-table-container
+:::table-overflow
 | 6.0 Hex Code | 6.0 CSS Name             | 7.0 Hex Code | 7.0 Design Token               |
 |--------------|--------------------------|--------------|--------------------------------|
 | #CBDEE9      | `--colorPrimaryLighten4` | #CBDEE9      | `--color-palette-darkblue-100` |
@@ -73,7 +73,7 @@ All color pairings should follow the latest WCAG AA contrast rules. Astro compon
 
 ### Secondary Palette
 
-:::specs-table-container
+:::table-overflow
 | 6.0 Hex Code | 6.0 CSS Name                | 7.0 Hex Code | 7.0 Design Token                 |
 |--------------|-----------------------------|--------------|----------------------------------|
 | #DAEEFF      | `--colorSecondaryLighten4`  | #DAEEFF      | `--color-palette-brightblue-100` |
@@ -90,7 +90,7 @@ All color pairings should follow the latest WCAG AA contrast rules. Astro compon
 
 ### Tertiary Palette
 
-:::specs-table-container
+:::table-overflow
 | 6.0 Hex Code | 6.0 CSS Name               | 7.0 Hex Code | 7.0 Design Token           |
 |--------------|----------------------------|--------------|----------------------------|
 | #D4D8DD      | `--colorTertiaryLighten4`  | #F5F6F9      | `--color-palette-grey-100` |
@@ -111,7 +111,7 @@ The Quaternary Palette has been removed entirely.
 
 ### Tag 1 Palette
 
-:::specs-table-container
+:::table-overflow
 | 6.0 Hex Code | 6.0 CSS Name          | 7.0 Hex Code | 7.0 Design Token           |
 |--------------|-----------------------|--------------|----------------------------|
 | #D0F4F4      | `--colorTag1Lighten4` | #D0F4F4      | `--color-palette-teal-100` |
@@ -127,7 +127,7 @@ The Quaternary Palette has been removed entirely.
 
 ### Tag 2 Palette
 
-:::specs-table-container
+:::table-overflow
 | 6.0 Hex Code | 6.0 CSS Name          | 7.0 Hex Code | 7.0 Design Token             |
 |--------------|-----------------------|--------------|------------------------------|
 | #E4E2F7      | `--colorTag2Lighten4` | #E4E2F7      | `--color-palette-purple-100` |
@@ -143,7 +143,7 @@ The Quaternary Palette has been removed entirely.
 
 ### Tag 3 Palette
 
-:::specs-table-container
+:::table-overflow
 | 6.0 Hex Code | 6.0 CSS Name          | 7.0 Hex Code | 7.0 Design Token           |
 |--------------|-----------------------|--------------|----------------------------|
 | #EDCEF3      | `--colorTag3Lighten4` | #EDCEF3      | `--color-palette-pink-100` |
@@ -159,7 +159,7 @@ The Quaternary Palette has been removed entirely.
 
 ### Tag 4 Palette
 
-:::specs-table-container
+:::table-overflow
 | 6.0 Hex Code | 6.0 CSS Name          | 7.0 Hex Code | 7.0 Design Token                |
 |--------------|-----------------------|--------------|---------------------------------|
 | #F8DDD1      | `--colorTag4Lighten4` | #F8DDD1      | `--color-palette-hotorange-100` |

--- a/src/pages/design-guidelines/grid.md
+++ b/src/pages/design-guidelines/grid.md
@@ -22,7 +22,7 @@ The Astro Grid is a standard 12 [column](https://developer.mozilla.org/en-US/doc
 
 At certain screen sizes, Astro optimizes for display on narrow devices by reducing the number of columns and rearranging the layout of your application via [responsive design](https://developers.google.com/web/fundamentals/design-and-ux/responsive/) practices.
 
-:::specs-table-container
+:::table-overflow
 | Breakpoint                       | Columns | Margin | Gap  | Gap (compact) |
 |----------------------------------|---------|--------|------|---------------|
 | 0-360px                          | 4       | 16px   | 16px | 8px           |

--- a/src/pages/design-guidelines/typography.md
+++ b/src/pages/design-guidelines/typography.md
@@ -14,7 +14,7 @@ Astro uses the open source typeface [Roboto](https://fonts.google.com/specimen/R
 
 Astro supports two levels of display text.
 
-:::specs-table-container
+:::table-overflow
 | Style     | Weight        | Font Size        | Letter Spacing | Line Height       | Class            | Design Token Identifier |
 |-----------|---------------|------------------|----------------|-------------------|------------------|-------------------------|
 | Display 1 | Light (300)   | 3.75 rem (60 px) | -0.50          | 4.375 rem (70 px) | `.rux-display-1` | `display-1`             |
@@ -25,7 +25,7 @@ Astro supports two levels of display text.
 
 Astro supports six levels of headline text.
 
-:::specs-table-container
+:::table-overflow
 | Style          | Weight        | Font Size         | Letter Spacing | Line Height      | Class                 | Design Token Identifier |
 |----------------|---------------|-------------------|----------------|------------------|-----------------------|-------------------------|
 | Heading 1      | Regular (400) | 2.125 rem (34 px) | 0.25           | 2.5 rem (40 px)  | `.rux-heading-1`      | `heading-1`             |
@@ -41,7 +41,7 @@ Astro supports six levels of headline text.
 
 The default font size in Astro is 1 rem/16 px. Astro supports three additional font sizes for body copy.
 
-:::specs-table-container
+:::table-overflow
 | Style               | Weight        | Font Size         | Letter Spacing | Line Height      | Class                      | Design Token Identifier |
 |---------------------|---------------|-------------------|----------------|------------------|----------------------------|-------------------------|
 | Body 1              | Regular (400) | 1 rem (16 px)     | 0.50           | 1.5 rem (24 px)  | `.rux-body-1`              | `body-1`                |

--- a/src/pages/design-tokens/installation.md
+++ b/src/pages/design-tokens/installation.md
@@ -67,7 +67,7 @@ A `light-theme` class that includes Astro's light theme.
 
 A few utility classes for applying Astro typography.
 
-:::specs-table-container
+:::table-overflow
 | Style               | Class                      |
 |---------------------|----------------------------|
 | Body 1              | `.rux-body-1`              |

--- a/src/pages/getting-started/developers.md
+++ b/src/pages/getting-started/developers.md
@@ -25,7 +25,7 @@ You can review the latest versions of the web components at the [Astro Storybook
 
 For online examples of full Astro app experiences, check out these EGS Service-Specific sample experiences:
 
-:::specs-table-container
+:::table-overflow
 | Ground Resources Management                                                                                                                               | Telemetry, Tracking, and Control                                                                                                     |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | [Dashboard](/grm-service-ux-design/grm-dashboard/) - [Source code](https://bitbucket.org/rocketcom/grm-sample-apps-dashboard/src/master/)                 | [Monitor](/ttc-service-ux-design/ttc-monitor/) - [Source code](https://bitbucket.org/rocketcom/tt-c-monitor/src/master/)             |

--- a/src/pages/getting-started/index.md
+++ b/src/pages/getting-started/index.md
@@ -37,7 +37,7 @@ Learn more about designing with Astro development assets, and why the Astro team
 
 Astro is tested & supported in major 'evergreen' web browsers (the latest browser version from each vendor -1). Please submit an issue for problems with the browsers listed below. Mobile browsers are not yet fully supported in Astro.
 
-:::specs-table-container
+:::table-overflow
 |       | Chrome  | Firefox |  Edge   | Safari  | Chrome (Android) | Safari (iOS) |
 |:------|:-------:|:-------:|:-------:|:-------:|:----------------:|:------------:|
 | Astro | &check; | &check; | &check; | &check; |   unsupported    | unsupported  |

--- a/src/pages/grm-service-ux-design/grm-dashboard.md
+++ b/src/pages/grm-service-ux-design/grm-dashboard.md
@@ -103,7 +103,7 @@ Below is an animated walkthrough of a representative task flow using the GRM Das
 
 Below are design and development resources to get you started on an app that supports GRM services. Note that there are some discrepancies between the design documents and the [GRM Dashboard Sample App](https://grm-dashboard.astrouxds.com/) due to design improvements that were introduced late in the app development cycle.
 
-:::specs-table-container
+:::table-overflow
 | Resources                                                                                                                                       | Description                                                                                                                                                |
 |-------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [GRM Design Specifications (pdf)](http://com.rocketcom.astrouxds.s3.amazonaws.com/attachments/cjx3r384i2gbihmqnxcwrq25d-grm-specifications.pdf) | The GRM Design Specification contains information on use cases, task flows, UX research and wireframes for key features of the GRM App Suite.              |

--- a/src/pages/grm-service-ux-design/grm-equipment-manager.md
+++ b/src/pages/grm-service-ux-design/grm-equipment-manager.md
@@ -109,7 +109,7 @@ Below is an animated walkthrough of a representative task flow using the GRM Equ
 
 Below are design and development resources to get you started on an app that supports GRM equipment management. Note that there are some discrepancies between the design documents and the [GRM Equipment Manager Sample App](https://grm-equipment.astrouxds.com/) due to design improvements that were introduced late in the app development cycle.
 
-:::specs-table-container
+:::table-overflow
 | Resources                                                                                                                                       | Description                                                                                                                                                |
 |-------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [GRM Design Specifications (pdf)](http://com.rocketcom.astrouxds.s3.amazonaws.com/attachments/cjx3r384i2gbihmqnxcwrq25d-grm-specifications.pdf) | The GRM Design Specification contains information on use cases, task flows, UX research and wireframes for key features of the GRM App Suite.              |

--- a/src/pages/grm-service-ux-design/grm-schedule.md
+++ b/src/pages/grm-service-ux-design/grm-schedule.md
@@ -97,7 +97,7 @@ Below is an animated walkthrough of a representative task flow using the GRM Sch
 
 Below are design and development resources to get you started on an app that supports GRM equipment management. Note that there are some discrepancies between the design documents and the [GRM Schedule Sample App](https://grm-equipment.astrouxds.com/) due to design improvements that were introduced late in the app development cycle.
 
-:::specs-table-container
+:::table-overflow
 | Resources                                                                                                                                       | Description                                                                                                                                                |
 |-------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [GRM Design Specifications (pdf)](http://com.rocketcom.astrouxds.s3.amazonaws.com/attachments/cjx3r384i2gbihmqnxcwrq25d-grm-specifications.pdf) | The GRM Design Specification contains information on use cases, task flows, UX research and wireframes for key features of the GRM App Suite.              |

--- a/src/pages/ttc-service-ux-design/ttc-command.md
+++ b/src/pages/ttc-service-ux-design/ttc-command.md
@@ -97,7 +97,7 @@ Below is an animated walkthrough of a representative task flow using the TT&C Mo
 
 Below are design and development resources to get you started on an app that supports TT&C services. Note that there are some discrepancies between the design documents and the [TT&C Command Sample App](https://ttc-command.astrouxds.com/) due to design improvements that were introduced late in the app development cycle.
 
-:::specs-table-container
+:::table-overflow
 | Resources                                                                                                                       | Description                                                                                                                                               |
 |---------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [TT&C Design Specifications (pdf)](https://s3-us-west-2.amazonaws.com/com.rocketcom.astrouxds/downloads/ttc-specifications.pdf) | The TT&C Design Specification contains information on use cases, task flows, UX research and wireframes for key features of the TT&C App Suite.           |

--- a/src/pages/ttc-service-ux-design/ttc-investigate.md
+++ b/src/pages/ttc-service-ux-design/ttc-investigate.md
@@ -89,7 +89,7 @@ Below is an animated walkthrough of a representative task flow using the TT&C In
 
 Below are design and development resources to get you started on an app that supports TT&C services. Note that there are some discrepancies between the design documents and the [TT&C Investigate Sample App](https://ttc-investigate.astrouxds.com/) due to design improvements that were introduced late in the app development cycle.
 
-:::specs-table-container
+:::table-overflow
 | Resources                                                                                                                       | Description                                                                                                                                                   |
 |---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [TT&C Design Specifications (pdf)](https://s3-us-west-2.amazonaws.com/com.rocketcom.astrouxds/downloads/ttc-specifications.pdf) | The TT&C Design Specification contains information on use cases, task flows, UX research and wireframes for key features of the TT&C App Suite.               |

--- a/src/pages/ttc-service-ux-design/ttc-monitor.md
+++ b/src/pages/ttc-service-ux-design/ttc-monitor.md
@@ -112,7 +112,7 @@ Below is an animated walkthrough of a representative task flow using the TT&C Mo
 
 Below are design and development resources to get you started on an app that supports TT&C services. Note that there are some discrepancies between the design documents and the [TT&C Monitor Sample App](https://ttc-monitor.astrouxds.com/) due to design improvements that were introduced late in the app development cycle.
 
-:::specs-table-container
+:::table-overflow
 | Resources                                                                                                                       | Description                                                                                                                                               |
 |---------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [TT&C Design Specifications (pdf)](https://s3-us-west-2.amazonaws.com/com.rocketcom.astrouxds/downloads/ttc-specifications.pdf) | The TT&C Design Specification contains information on use cases, task flows, UX research and wireframes for key features of the TT&C App Suite.           |


### PR DESCRIPTION
This change updates markdown tables to use an overflow fix that improves the styling on smaller-width devices.