### PR TITLE
fix(feedback-widget): solution for widget slide-in on mobile

### DIFF
--- a/src/components/feedback-widgets/feedback-widget-custom-element.ts
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.ts
@@ -23,6 +23,7 @@ class FeedbackWidget extends HTMLElement {
 		const widgetInteriorWrapper: HTMLElement | null = document.querySelector('.widget_interior-wrapper')
 		const topTab: HTMLElement | null = document.querySelector('.widget_top-tab')
 		const widgetContent: HTMLElement | null = document.querySelector('.widget_content-wrapper')
+		const pageFooter: HTMLElement = document.querySelector('.p-footer')!
 
 		// shadow elements
 		const form: HTMLFormElement = root.querySelector('form#feedback-form')!
@@ -43,6 +44,9 @@ class FeedbackWidget extends HTMLElement {
 		let rateButtonSelected: boolean = false
 		let formSubmittable: boolean = false
 		let toggle: boolean = false
+
+		// intersection observer
+		let observer: IntersectionObserver | undefined
 
 		const handleRemoveSelected = () => {
 			// deselect UI buttons
@@ -82,18 +86,22 @@ class FeedbackWidget extends HTMLElement {
 			}
 		}
 
+		const watchFooterScroll = () => {
+			let footerBottom: number = pageFooter.getBoundingClientRect().top
+			let viewportHeight: number = visualViewport.height
+			let difference: number = (footerBottom - viewportHeight) * -1
+
+			if (widgetWrapper !== null) widgetWrapper.style.insetBlockEnd = `${difference}px`
+			console.log('difference', difference)
+		}
+
 		const watchForFooter = () => {
-			const pageFooter: HTMLElement = document.querySelector('.p-footer')!
-
-			const watchFooterScroll = () => {
-				let footerBottom: number = pageFooter.getBoundingClientRect().top
-				let viewportHeight: number = visualViewport.height
-				let difference: number = (footerBottom - viewportHeight) * -1
-
-				if (widgetWrapper !== null) widgetWrapper.style.insetBlockEnd = `${difference}px`
-				console.log('difference', difference)
+			if (observer) observer.disconnect()
+			if (visualViewport.width > 1024) {
+				return
 			}
-			function handleIntersect(entries: any[], observer: any) {
+
+			const handleIntersect = (entries: any[]) => {
 				entries.forEach((entry) => {
 					if (entry.isIntersecting) {
 						document.addEventListener('scroll', watchFooterScroll)
@@ -103,9 +111,6 @@ class FeedbackWidget extends HTMLElement {
 					}
 				})
 			}
-
-			let observer
-
 
 			let options = {
 				root: null,
@@ -337,6 +342,10 @@ class FeedbackWidget extends HTMLElement {
 		handleEmailListener()
 		handleFormListener()
 		watchForFooter()
+		window.addEventListener('resize', () => {
+			document.removeEventListener('scroll', watchFooterScroll)
+			watchForFooter()
+		})
 	}
 }
 

--- a/src/components/feedback-widgets/feedback-widget-custom-element.ts
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.ts
@@ -19,6 +19,7 @@ class FeedbackWidget extends HTMLElement {
 		currentURLInput.setAttribute('value', currentURL)
 
 		// document elements
+		const widgetWrapper: HTMLElement | null = document.querySelector('.widget_wrapper')
 		const widgetInteriorWrapper: HTMLElement | null = document.querySelector('.widget_interior-wrapper')
 		const topTab: HTMLElement | null = document.querySelector('.widget_top-tab')
 		const widgetContent: HTMLElement | null = document.querySelector('.widget_content-wrapper')
@@ -79,6 +80,41 @@ class FeedbackWidget extends HTMLElement {
 			} else {
 				submitButton.disabled = false
 			}
+		}
+
+		const watchForFooter = () => {
+			const pageFooter: HTMLElement = document.querySelector('.p-footer')!
+
+			const watchFooterScroll = () => {
+				let footerBottom: number = pageFooter.getBoundingClientRect().top
+				let viewportHeight: number = visualViewport.height
+				let difference: number = (footerBottom - viewportHeight) * -1
+
+				if (widgetWrapper !== null) widgetWrapper.style.insetBlockEnd = `${difference}px`
+				console.log('difference', difference)
+			}
+			function handleIntersect(entries: any[], observer: any) {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						document.addEventListener('scroll', watchFooterScroll)
+					} else {
+						document.removeEventListener('scroll', watchFooterScroll)
+						if (widgetWrapper !== null) widgetWrapper.style.insetBlockEnd = `0px`
+					}
+				})
+			}
+
+			let observer
+
+
+			let options = {
+				root: null,
+				rootMargin: '0px',
+				threshold: 0,
+			}
+
+			observer = new IntersectionObserver(handleIntersect, options)
+			observer.observe(pageFooter)
 		}
 
 		const showHideWidget = () => {
@@ -300,6 +336,7 @@ class FeedbackWidget extends HTMLElement {
 		handleTextareaListener()
 		handleEmailListener()
 		handleFormListener()
+		watchForFooter()
 	}
 }
 

--- a/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
+++ b/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
@@ -97,7 +97,9 @@
 		block-size: auto;
 		inline-size: 75--step;
 		max-block-size: calc(100dvh - 15--step);
-		overflow-y: auto;
+
+		/* Layout */
+		overflow-y: hidden;
 		padding-block: 5--step;
 		padding-inline: 3--step;
 		position: relative;

--- a/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
+++ b/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
@@ -13,19 +13,22 @@
 	margin-inline-end: 4--step;
 
 	/* Appearance */
-	position: fixed;
-
-	& .widget_interior-wrapper {
-		/* Layout */
-		inset-block-end: 0;
-		position: absolute;
-	}
+	position: sticky;
 
 	@media (width < 1024px) {
 		/* Layout */
 		inset-block-end: 0;
 		inset-inline-end: 0;
 		margin-inline-end: 0;
+
+		/* Layout */
+		position: fixed;
+	}
+
+	& .widget_interior-wrapper {
+		/* Layout */
+		inset-block-end: 0;
+		position: absolute;
 	}
 
 	& .widget_top-tab {

--- a/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
+++ b/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
@@ -95,6 +95,8 @@
 	& .widget_content-wrapper {
 		/* Layout */
 		block-size: auto;
+
+		/* Layout */
 		inline-size: 75--step;
 		max-block-size: calc(100dvh - 15--step);
 
@@ -123,6 +125,12 @@
 
 			/* Appearance */
 			border: none;
+
+			@media (width < 1024px) {
+				/* Layout */
+				block-size: auto;
+				inline-size: 0;
+			}
 		}
 
 		&:is([data-collapsible-active]) {
@@ -133,6 +141,11 @@
 
 			/* Appearance */
 			border: 1px solid #2f7aa7;
+
+			@media (width < 1024px) {
+				/* Layout */
+				inline-size: 75--step;
+			}
 		}
 
 		& h3 {

--- a/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
+++ b/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
@@ -13,7 +13,7 @@
 	margin-inline-end: 4--step;
 
 	/* Appearance */
-	position: sticky;
+	position: fixed;
 
 	& .widget_interior-wrapper {
 		/* Layout */

--- a/src/components/icon-search/icon-search.client.ts
+++ b/src/components/icon-search/icon-search.client.ts
@@ -30,8 +30,8 @@ const setIconPanelPosition = () => {
 	let searchRect: number = iconSearch?.getBoundingClientRect().y
 	let offset: number = searchRect + iconSearchHeight
   if (window.visualViewport.pageTop > pageHeaderPlusNavHeight) {
-	sidePanel.style.insetBlockStart = `${iconSearchHeight}px`
-	sidePanel.style.blockSize = `calc(100dvh - ${iconSearchHeight}px)`
+	sidePanel.style.insetBlockStart = `${iconSearchHeight + navHeight}px`
+	sidePanel.style.blockSize = `calc(100dvh - ${iconSearchHeight + navHeight}px)`
   } else {
     sidePanel.style.insetBlockStart = `${offset}px`
 	sidePanel.style.blockSize = `calc(100dvh - ${offset}px)`

--- a/src/components/icon-search/icon-search.css
+++ b/src/components/icon-search/icon-search.css
@@ -8,6 +8,9 @@
 	padding-block: 7--step;
 	padding-inline: 8--step;
 
+	/* Accounting for being a higher z than the feedback widget tab */
+	z-index: 2;
+
 	/* Appearance */
 	background-color: var(--PrimaryColor);
 	//box-shadow: -2px 2px 4px #00000040;

--- a/src/components/icon-search/parts/side-panel.shadow.css
+++ b/src/components/icon-search/parts/side-panel.shadow.css
@@ -71,6 +71,9 @@ h2 {
 	padding-inline: 6--step;
 	position: fixed;
 
+	/* Accounting for being a higher z than the feedback widget tab */
+	z-index: 2;
+
 	/* Appearance */
 	background-color: var(--DarkBlue800Color);
 	color: var(--PrimaryColor);

--- a/src/layouts/default/style/sanitize.css
+++ b/src/layouts/default/style/sanitize.css
@@ -11,6 +11,8 @@
 ::after {
 	/* Layout */
 	box-sizing: border-box; /* 1 */
+
+	/* Layout */
 	background-repeat: no-repeat; /* 2 */
 }
 
@@ -36,10 +38,15 @@
  */
 
 :where(:root) {
+	/* Layout */
+	overflow-x: hidden;
+
 	/* Text */
 	line-height: 1.5; /* 2 */ /* 4 */
 	tab-size: 4; /* 4 */
 	text-size-adjust: 100%; /* 6 */
+
+	/* Text */
 	cursor: default; /* 1 */
 	-webkit-tap-highlight-color: transparent; /* 5 */
 	overflow-wrap: break-word; /* 3 */
@@ -89,7 +96,9 @@
 
 :where(hr) {
 	/* Layout */
-	height: 0; /* 2 */
+	block-size: 0; /* 2 */
+
+	/* Layout */
 	color: inherit; /* 1 */
 }
 
@@ -113,6 +122,7 @@
 :where(pre) {
 	/* Layout */
 	overflow: auto; /* 3 */
+	/* stylelint-disable-next-line font-family-no-duplicate-names */
 	font-family: monospace, monospace; /* 1 */
 	font-size: 1em; /* 2 */
 }
@@ -136,6 +146,7 @@
 
 :where(b, strong) {
 	/* Text */
+	/* stylelint-disable-next-line font-weight-notation */
 	font-weight: bolder;
 }
 
@@ -146,6 +157,7 @@
 
 :where(code, kbd, samp) {
 	/* Text */
+	/* stylelint-disable-next-line font-family-no-duplicate-names */
 	font-family: monospace, monospace; /* 1 */
 	font-size: 1em; /* 2 */
 }
@@ -199,6 +211,8 @@
 :where(table) {
 	/* Text */
 	text-indent: 0; /* 3 */
+
+	/* Text */
 	border-collapse: collapse; /* 1 */
 	border-color: inherit; /* 2 */
 }
@@ -271,7 +285,7 @@
 ::-webkit-inner-spin-button,
 ::-webkit-outer-spin-button {
 	/* Layout */
-	height: auto;
+	block-size: auto;
 }
 
 /**
@@ -313,17 +327,17 @@
 
 :where(dialog) {
 	/* Layout */
-	height: fit-content;
+	block-size: fit-content;
+	inline-size: fit-content;
 	inset-inline: 0;
 	margin: auto;
 	padding: 1em;
 	position: absolute;
-	width: fit-content;
 
 	/* Appearance */
-	background-color: white;
+	background-color: #ffffff;
 	border: solid;
-	color: black;
+	color: #000000;
 }
 
 :where(dialog:not([open])) {

--- a/src/layouts/default/style/sanitize.css
+++ b/src/layouts/default/style/sanitize.css
@@ -38,9 +38,6 @@
  */
 
 :where(:root) {
-	/* Layout */
-	overflow-x: hidden;
-
 	/* Text */
 	line-height: 1.5; /* 2 */ /* 4 */
 	tab-size: 4; /* 4 */


### PR DESCRIPTION
This PR includes:

- A fix for feedback widget slide-in animation on mobile. previously, the slide-in would push the content and zoom the page, but only on actual mobile devices. This fix changes the positioning of the widget from fixed to sticky, but only on mobile viewports. To account for the widget tab stopping at the footer an intersection observer was added on the footer which adds and removes a scroll event listener that dynamically positions the feedback widget tab on scroll, but only when the user is scrolling through the footer.
- A fix on the icon library page where the feedback widget tab was overlaying the icon side-panel when open. Now it falls underneath it.
- A fix for the icon library side-panel on mobile. The nav is now sticky on mobile, and the positioning of the icon side-panel was not accounting for that.