### PR TITLE
fix(nav + content) Fixing content expanding to fit nav-height and leaving whitespace at bottom

### DIFF
--- a/src/components/site-navigation/site-navigation.css
+++ b/src/components/site-navigation/site-navigation.css
@@ -27,7 +27,7 @@
 
 	@media (width >= 1024px) {
 		/* Layout */
-		block-size: min(100%, 100vh);
+		block-size: 100vh;
 		inline-size: 78--step;
 		overflow-x: hidden;
 		overflow-y: auto;


### PR DESCRIPTION
This PR fixes an issue where if some of the trees in the nav were expanded the shorter pages would then expand to fill that space as well, leaving weird whitespace at the bottom that is more noticeable now with the sticky widget.