### PR TITLE
css(anchor links) move the anchor ing to the end of headings rather than the beginning

### DIFF
--- a/src/layouts/new-docs/style/heading-anchors.css
+++ b/src/layouts/new-docs/style/heading-anchors.css
@@ -8,13 +8,14 @@ a.h {
 	& > * {
 		display: flex;
 
-		&::before {
+		&::after {
 			display: inline-block;
 
 			/* Layout */
 			block-size: 1--icon-size;
 			inline-size: 1--icon-size;
-			margin-inline: -1.25--icon-size .25--icon-size;
+			margin-block-start: .1rem;
+			margin-inline: .25--icon-size;
 
 			/* Appearance */
 			opacity: 0;
@@ -29,7 +30,7 @@ a.h {
 
 	&:hover:not(:focus-visible) {
 		& > * {
-			&::before {
+			&::after {
 				/* Appearance */
 				opacity: 60%;
 			}


### PR DESCRIPTION
Just a small tweak. I was asked if we could move the anchor link images in the headers over to the right on the /next/ branch. People seemed to like it but I wanted to wait to finalize until I could build off main.
[ASTRO-6081](https://rocketcom.atlassian.net/browse/ASTRO-6081)