### PR TITLE
fix(nav): moving app state link down below the divider line in components on the nav.

### DIFF
--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -126,16 +126,16 @@
 				"url": "/components/component-sandbox/"
 			},
 			{
-				"label": "Application State",
-				"url": "/components/application-state/"
-			},
-			{
 				"label": "separator",
 				"url": "/separator"
 			},
 			{
 				"label": "Accordion",
 				"url": "/components/accordion/"
+			},
+			{
+				"label": "Application State",
+				"url": "/components/application-state/"
 			},
 			{
 				"label": "Button",


### PR DESCRIPTION
This PR is a tiny change to the navigation JSON file that moves the Application State link in the nav down below the divider line, as it is technically a component.