### PR TITLE
fix(homepage): Fixing homepage blocks not being clickable on mobile

### DIFF
--- a/src/components/home/articles/home-articles.css
+++ b/src/components/home/articles/home-articles.css
@@ -123,16 +123,14 @@
 		-webkit-box-orient: vertical;
 
 		& > a {
-			@media (hover: hover) {
-				&::before {
-					/* Layout */
-					inset: 0;
-					position: absolute;
-					z-index: 1;
+			&::before {
+				/* Layout */
+				inset: 0;
+				position: absolute;
+				z-index: 1;
 
-					/* Generated */
-					content: "";
-				}
+				/* Generated */
+				content: "";
 			}
 		}
 	}

--- a/src/components/home/articles/home-articles.css
+++ b/src/components/home/articles/home-articles.css
@@ -123,14 +123,16 @@
 		-webkit-box-orient: vertical;
 
 		& > a {
-			&::before {
-				/* Layout */
-				inset: 0;
-				position: absolute;
-				z-index: 1;
+			@media (hover: hover), (pointer: coarse) {
+				&::before {
+					/* Layout */
+					inset: 0;
+					position: absolute;
+					z-index: 1;
 
-				/* Generated */
-				content: "";
+					/* Generated */
+					content: "";
+				}
 			}
 		}
 	}

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -395,16 +395,14 @@
 	font-size: 20--rpx;
 	line-height: calc(24 / 20);
 
-	@media (hover: hover) {
-		& a::before {
-			/* Layout */
-			inset: 0;
-			position: absolute;
-			z-index: 1;
+	& a::before {
+		/* Layout */
+		inset: 0;
+		position: absolute;
+		z-index: 1;
 
-			/* Generated */
-			content: "";
-		}
+		/* Generated */
+		content: "";
 	}
 
 	@media (width >= 1024px) and (width < 1200px) {

--- a/src/components/home/community/home-community.css
+++ b/src/components/home/community/home-community.css
@@ -395,14 +395,16 @@
 	font-size: 20--rpx;
 	line-height: calc(24 / 20);
 
-	& a::before {
-		/* Layout */
-		inset: 0;
-		position: absolute;
-		z-index: 1;
+	@media (hover: hover), (pointer: coarse) {
+		& a::before {
+			/* Layout */
+			inset: 0;
+			position: absolute;
+			z-index: 1;
 
-		/* Generated */
-		content: "";
+			/* Generated */
+			content: "";
+		}
 	}
 
 	@media (width >= 1024px) and (width < 1200px) {

--- a/src/components/home/explainer/home-explainer.css
+++ b/src/components/home/explainer/home-explainer.css
@@ -115,14 +115,16 @@
 				/* Appearance */
 			}
 
-			&::before {
-				/* Layout */
-				inset: 0;
-				position: absolute;
-				z-index: 1;
+			@media (hover: hover), (pointer: coarse) {
+				&::before {
+					/* Layout */
+					inset: 0;
+					position: absolute;
+					z-index: 1;
 
-				/* Generated */
-				content: "";
+					/* Generated */
+					content: "";
+				}
 			}
 		}
 	}

--- a/src/components/home/explainer/home-explainer.css
+++ b/src/components/home/explainer/home-explainer.css
@@ -115,16 +115,14 @@
 				/* Appearance */
 			}
 
-			@media (hover: hover) {
-				&::before {
-					/* Layout */
-					inset: 0;
-					position: absolute;
-					z-index: 1;
+			&::before {
+				/* Layout */
+				inset: 0;
+				position: absolute;
+				z-index: 1;
 
-					/* Generated */
-					content: "";
-				}
+				/* Generated */
+				content: "";
 			}
 		}
 	}


### PR DESCRIPTION
This fix removes the styling `@media (hover: hover)` on the homepage blocks which was preventing the clickable link that gets expanded using a `::before` from working on mobile.