### PR TITLE
Update standalone image without figure

### DIFF
--- a/.vscode/astro-plugins.js
+++ b/.vscode/astro-plugins.js
@@ -10,6 +10,7 @@ import remarkDirectives from './remark-plugins/remark-directives.js'
 import remarkDoDontFigures from './remark-plugins/remark-do-dont-figures.js'
 import remarkGfm from 'remark-gfm'
 import remarkHeadingLinks from './remark-plugins/remark-heading-links.js'
+import remarkImageTitleAsAlt from './remark-plugins/remark-image-title-as-alt.js'
 import remarkImplicitFigures from './remark-plugins/remark-implicit-figures.js'
 import remarkLazyImages from './remark-plugins/remark-lazy-images.js'
 import remarkLists from './remark-plugins/remark-lists.js'
@@ -43,6 +44,7 @@ function astroWWWIntegration() {
 								command,
 							}),
 							remarkImplicitFigures,
+							remarkImageTitleAsAlt,
 							remarkDoDontFigures,
 							remarkLists,
 							remarkHeadingLinks,

--- a/.vscode/remark-plugins/remark-image-title-as-alt.js
+++ b/.vscode/remark-plugins/remark-image-title-as-alt.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @typedef {import('unist').Node} Node */
+/** @typedef {Node & { title?: string; url?: string; alt?: string }} ImageNode */
+/** @typedef {import('unist').Parent} ParagraphNode */
+
+import { visit } from 'unist-util-visit'
+
+/** Transforms a standalone image with a title and no alt into a plain image with an alt. */
+export default function remarkImageTitleAsAlt() {
+	return (/** @type {Node} */ tree) => {
+		visit(tree, 'paragraph', (/** @type {ParagraphNode} */ paragraph) => {
+			const children = paragraph.children
+
+			if (!children || children.length !== 1) return
+
+			/** @type {ImageNode} */
+			const image = children[0]
+
+			if (!image || image.type !== 'image' || !!image.alt || !image.title) return
+
+			image.alt = image.title
+
+			delete image.title
+		})
+	}
+}

--- a/src/pages/patterns/status-system.md
+++ b/src/pages/patterns/status-system.md
@@ -1,6 +1,6 @@
 ---
 title: Status System
-description: Consistent use of colors and symbols to convey status is critical for user success. 
+description: Consistent use of colors and symbols to convey status is critical for user success.
 tags: resources
 path: /patterns/status-system
 date: Last Modified
@@ -16,7 +16,7 @@ The Astro Status System is a standard to consistently indicate the state of an o
 
 The Status Color palette for the Status System is based on a color temperature scale. The lowest level of severity, Off, is grey (neutral) and the highest level of severity, Alert, is red (hot).
 
-![Status System Taxonomy](/img/patterns/status-system-fundamentals.png "Figure 3.1.1 Status system taxonomy")
+![](/img/patterns/status-system-fundamentals.png "Status System Taxonomy")
 
 Each Status Symbol is a combination of a Status Color and a shape. The shapes are provided to ensure people with color blindness can also clearly identify the state of the object or concept
 


### PR DESCRIPTION
[Preview](https://deploy-preview-209--astrouxds.netlify.app/patterns/status-system/)

This change updates the abilities of Markdown to support a standalone image without a figure.

It also removes one image caption from the Status System page.

--convert to draft -- kiley: I still want to do this but I need a little time with it.