### PR TITLE
Use file nesting in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,17 @@
 	"editor.insertSpaces": false,
 	"editor.useTabStops": true,
 
+	"explorer.fileNesting.enabled": true,
+	"explorer.fileNesting.expand": false,
+	"explorer.fileNesting.patterns": {
+		"*.astro": "$(capture).*",
+		"*.png": "$(capture).webp",
+		"*.record.json": "$(capture).schema.json, $(capture).*.ts",
+		"*.json": "$(capture).schema.json, $(capture).d.json.ts",
+		"index.*": "*",
+		"package.json": ".*, astro*, netlify*, tsconfig*"
+	},
+
 	"files.exclude": {
 		"**/.vscode": false,
 		"**/*.lock": true,

--- a/src/data/asset-status.d.json
+++ b/src/data/asset-status.d.json
@@ -1,1 +1,0 @@
-export declare const data: Record<string, any>

--- a/src/data/compliance-footer.d.json.ts
+++ b/src/data/compliance-footer.d.json.ts
@@ -1,0 +1,24 @@
+export interface Field {
+	type: string
+	data: string
+
+	[key: string]: any
+}
+
+export interface LinkField {
+	data: {
+		url: string;
+		alt: string;
+	}
+}
+
+export interface ComplianceFooter {
+	type: string
+	data: {
+		title: Field
+		version: Field
+		link: LinkField
+	}
+}
+
+export default Object as ComplianceFooter

--- a/src/data/compliance.d.json.ts
+++ b/src/data/compliance.d.json.ts
@@ -30,4 +30,4 @@ export interface Compliance {
 export declare const version: Compliance['version']
 export declare const contents: Compliance['contents']
 
-export default null as Compliance
+export default Object as Compliance


### PR DESCRIPTION
Use file nesting to better organize related files in VSCode.

<img width="400" alt="JSON files with file nesting to group schemas and typing by record" src="https://user-images.githubusercontent.com/188426/234589823-31c1f1f7-e21c-4b8e-9077-12a262292597.png">

<img width="401" alt="Astro files with file nesting to group templates, styles, and scripts by the Astro entry point" src="https://user-images.githubusercontent.com/188426/234590206-b2b0dcef-d2c9-4b2f-956e-c98d02d9c264.png">
