### PR TITLE
fix(mobile-nav): adding search back to mobile nav

### DIFF
--- a/src/components/site-navigation/site-navigation.css
+++ b/src/components/site-navigation/site-navigation.css
@@ -110,10 +110,6 @@
 	inline-size: 100%;
 	margin-block-start: 7--step;
 	padding-inline: 11--step;
-
-	@media (width < 1024px) {
-		display: none;
-	}
 }
 
 /* Navigation: List */


### PR DESCRIPTION
This PR adds the search bar back into the nav on mobile. For some reason it was set to `display: none`, so having it hidden was intentional.