### PR TITLE
fix: removing versioning on Getting Started page.

### DIFF
--- a/src/pages/getting-started/index.md
+++ b/src/pages/getting-started/index.md
@@ -45,9 +45,9 @@ Astro is tested & supported in major 'evergreen' web browsers (the latest browse
 :::
 :::
 
-## Versioning
+<!-- ## Versioning
 
-Current version: 7.0
+Current version: 7.0 -->
 
 ## Astro Licensing
 


### PR DESCRIPTION
Removing the reference to 7.0 on the getting started page as it doesn't currently make sense to update to the actual version number from our bi-weekly release cadence.