### PR TITLE
fix(feedback widget): not sticking to bottom on 404 page

### DIFF
--- a/src/layouts/default/style/layout.css
+++ b/src/layouts/default/style/layout.css
@@ -29,7 +29,7 @@
 
 :where(.p-grid) {
 	/* Layout */
-	min-block-size: calc(100 * var(--vph));
+	block-size: calc(100 * var(--vph));
 
 	@media (width >= 1024px) {
 		display: grid;

--- a/src/layouts/new-docs/style/page.css
+++ b/src/layouts/new-docs/style/page.css
@@ -171,6 +171,9 @@
 }
 
 .page {
+	/* Layout */
+	block-size: 100%;
+
 	& li,
 	& p {
 		/* Layout */


### PR DESCRIPTION
This fix adds `block-size` 100% to the `<main>` element.