### PR TITLE
chore: bump WC version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	},
 	"devDependencies": {
 		"@astrojs/image": "0.16.6",
+		"@astrojs/markdown-remark": "2.1.4",
 		"@astrojs/mdx": "0.19.0",
 		"@astrojs/sitemap": "1.2.2",
 		"@astrojs/ts-plugin": "0.4.4",

--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -60,8 +60,8 @@ const description = `Astro represents a collection of artifacts including, but n
 				</tr>
 				<tr>
 					<td>Web Components</td>
-					<td class="tabular">7.9.1 -&gt; <b>7.9.2</b></td>
-					<td><a href="https://github.com/RocketCommunicationsInc/astro/releases/tag/v7.9.2">Release Notes</a></td>
+					<td class="tabular">7.9.3 -&gt; <b>7.10.0</b></td>
+					<td><a href="https://github.com/RocketCommunicationsInc/astro/releases/tag/v7.10.0">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>EGS Design Compliance</td>


### PR DESCRIPTION
just bumps the WC version on the releases page 