### PR TITLE
chore: update figma releases

### DIFF
--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -23,7 +23,7 @@ const description = `Astro represents a collection of artifacts including, but n
 				<tr>
 					<th colspan="3">
 						Astro { globalData.designSystem.version } - Updated
-						<time>March, 30 2023</time>
+						<time>May, 11 2023</time>
 					</th>
 				</tr>
 			</thead>
@@ -40,18 +40,23 @@ const description = `Astro represents a collection of artifacts including, but n
 				</tr>
 				<tr>
 					<td>Figma Dark Theme Library</td>
-					<td class="tabular">7.3.1 -&gt; <b>7.4.0</b></td>
+					<td class="tabular">7.5.0 -&gt; <b>7.6.0</b></td>
 					<td><a href="https://www.figma.com/community/file/1157371532469023309">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Light Theme Library</td>
-					<td class="tabular">7.0.1 -&gt; <b>7.1.0</b></td>
+					<td class="tabular">7.2.0 -&gt; <b>7.3.0</b></td>
 					<td><a href="https://www.figma.com/community/file/1203068683334364243">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Wireframe Theme Library</td>
-					<td class="tabular">7.0.1 -&gt; <b>7.1.0</b></td>
+					<td class="tabular">7.2.0 -&gt; <b>7.3.0</b></td>
 					<td><a href="https://www.figma.com/community/file/1203487593021750781">Release Notes</a></td>
+				</tr>
+				<tr>
+					<td>Astro Templates</td>
+					<td class="tabular">1.0.0</td>
+					<td><a href="https://www.figma.com/community/file/1238521463040620728">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Icon Library</td>


### PR DESCRIPTION
Updates figma libs on releases page, updates the 'last updated' date, adds new figma lib "astro templates"