### PR TITLE
fix(rux-input) add invalid switch to Input on playground

### DIFF
--- a/src/data/component-playgrounds.record.json
+++ b/src/data/component-playgrounds.record.json
@@ -1007,6 +1007,12 @@
 				},
 				{
 					"kind": "switch",
+					"attribute": "invalid",
+					"property": "invalid",
+					"checked": false
+				},
+				{
+					"kind": "switch",
 					"attribute": "required",
 					"property": "required",
 					"checked": false


### PR DESCRIPTION
[ASTRO-6328](https://rocketcom.atlassian.net/browse/ASTRO-6328)
Double checked the other components against storybook and it looks like the others that should have invalid props do have them.