### PR TITLE
chore: bump WC version in releases for 7.14

### DIFF
--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -23,7 +23,7 @@ const description = `Astro represents a collection of artifacts including, but n
 				<tr>
 					<th colspan="3">
 						Astro { globalData.designSystem.version } - Updated
-						<time>June, 22 2023</time>
+						<time>July, 6 2023</time>
 					</th>
 				</tr>
 			</thead>
@@ -35,22 +35,22 @@ const description = `Astro represents a collection of artifacts including, but n
 				</tr>
 				<tr>
 					<td>Design Tokens</td>
-					<td class="tabular">1.7.0 -&gt; <b>1.8.0</b></td>
+					<td class="tabular">1.8.0</td>
 					<td><a href="https://github.com/RocketCommunicationsInc/astro-design-tokens/releases/tag/v1.8.0">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Dark Theme Library</td>
-					<td class="tabular">7.6.1 -&gt; <b>7.6.2</b></td>
+					<td class="tabular">7.6.2</td>
 					<td><a href="https://www.figma.com/community/file/1157371532469023309">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Light Theme Library</td>
-					<td class="tabular">7.4.0 -&gt; <b>7.4.1</b></td>
+					<td class="tabular">7.4.1</td>
 					<td><a href="https://www.figma.com/community/file/1203068683334364243">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Wireframe Theme Library</td>
-					<td class="tabular">7.4.0 -&gt; <b>7.4.1</b></td>
+					<td class="tabular">7.4.1</td>
 					<td><a href="https://www.figma.com/community/file/1203487593021750781">Release Notes</a></td>
 				</tr>
 				<tr>
@@ -65,8 +65,8 @@ const description = `Astro represents a collection of artifacts including, but n
 				</tr>
 				<tr>
 					<td>Web Components</td>
-					<td class="tabular">7.12.0 -&gt; <b>7.13.0</b></td>
-					<td><a href="https://github.com/RocketCommunicationsInc/astro/releases/tag/v7.13.0">Release Notes</a></td>
+					<td class="tabular">7.13.0 -&gt; <b>7.14.0</b></td>
+					<td><a href="https://github.com/RocketCommunicationsInc/astro/releases/tag/v7.14.0">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>EGS Design Compliance</td>


### PR DESCRIPTION
Release 7.14 for WC's. 
No design releases this time 