### PR TITLE
EGS to R2C2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -131,7 +131,13 @@
 
 [[redirects]]
 	from = "/compliance"
-	to = "/compliance/egs-design-compliance"
+	to = "/compliance/r2c2-design-compliance"
+	status = 301
+	force = true
+
+[[redirects]]
+	from = "/egs-design-compliancee"
+	to = "/compliance/r2c2-design-compliance"
 	status = 301
 	force = true
 

--- a/src/data/compliance-footer.json
+++ b/src/data/compliance-footer.json
@@ -13,8 +13,8 @@
 		"link": {
 			"type": "link",
 			"data": {
-				"url": "/compliance/egs-design-compliance/",
-				"alt": "See all EGS Compliance Requirements"
+				"url": "/compliance/r2c2-design-compliance/",
+				"alt": "See all R2C2 Compliance Requirements"
 			}
 		}
 	}

--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -368,8 +368,8 @@
     {
         "items": [
             {
-                "label": "EGS Design Compliance",
-                "url": "/compliance/egs-design-compliance/"
+                "label": "R2C2 Design Compliance",
+                "url": "/compliance/r2c2-design-compliance/"
             },
             {
                 "label": "MIL-STD 1472H",

--- a/src/pages/compliance/index.astro
+++ b/src/pages/compliance/index.astro
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0;url=/compliance/egs-design-compliance/" />
+<meta http-equiv="refresh" content="0;url=/compliance/r2c2-design-compliance/" />

--- a/src/pages/compliance/r2c2-design-compliance/index.astro
+++ b/src/pages/compliance/r2c2-design-compliance/index.astro
@@ -3,7 +3,7 @@ import compliance from 'project:data/compliance.json'
 import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 import Compliance from 'project:components/compliance/compliance.astro'
 
-const title = 'EGS Design Compliance'
+const title = 'R2C2 Design Compliance'
 const description = 'Version 4.2.0'
 ---
 <DocsLayout content={{ title, description }} file={import.meta.url}>

--- a/src/pages/design-guidelines/compliance/index.astro
+++ b/src/pages/design-guidelines/compliance/index.astro
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0;url=/compliance/egs-design-compliance/" />
+<meta http-equiv="refresh" content="0;url=/compliance/r2c2-design-compliance/" />


### PR DESCRIPTION
This PR is to updates the main nav, template filename, redirects and links from EGS to R2C2. Another update with content will be coming. Happy to do those for a single PR if that’s preferable.