### PR TITLE
feat: add toast page, update playground with toast

### DIFF
--- a/src/data/asset-status.json
+++ b/src/data/asset-status.json
@@ -1,1849 +1,1893 @@
 {
-    "$schema": "./asset-status.schema.json",
-    "data": {
-        "Accordion": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-accordion--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "All Options": {
-            "assets": [
-                {
-                    "name": "Documentations",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "v7"
-                },
-                {
-                    "name": "UI Kit - Dark",
-                    "status": "inprogress",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "name": "UI Kit - Light",
-                    "status": "planned",
-                    "type": "ui",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Web Component",
-                    "status": "unavailable",
-                    "type": "component",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "deprecated",
-                    "type": "token",
-                    "version": "v7"
-                }
-            ]
-        },
-        "Application Feedback": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Breadcrumbs": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-breadcrumb--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Button": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-button--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "link": "/components/button/specs/",
-                    "name": "Component Tokens",
-                    "status": "available",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Card": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-card--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Checkbox": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/forms-checkbox-group--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Classification & Control Markings": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-classification-markings--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Clock": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-clock--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Container": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-container--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Data Visualization": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "name": "Web Component",
-                    "status": "unavailable",
-                    "type": "component",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "inprogress",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Date Picker": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "N/A"
-                },
-                {
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "N/A"
-                },
-                {
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Web Component",
-                    "status": "unavailable",
-                    "type": "component",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "unavailable",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Dialog": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-dialog--dialog",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Focus State": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Forms and Validation": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Global Status Bar": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-global-status-bar--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Icons and Symbols": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-monitoring-icon--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Input Field": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/forms-input--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "link": "/components/input-field/specs/",
-                    "name": "Component Tokens",
-                    "status": "available",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Link": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "name": "Web Component",
-                    "status": "unavailable",
-                    "type": "component",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Log": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-log--log",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Modeless Panes": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Monitoring Icon": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-monitoring-icon--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Navigation": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Notification Banner": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-notification--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Notifications": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Pagination": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "name": "Web Component",
-                    "status": "planned",
-                    "type": "component",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Pop Up": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-pop-up--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Pop Up Menu": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-pop-up--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Progress": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-progress--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Push Button": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-push-button--push-button",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Radio Button": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/forms-radio-group--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "inprogress",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Search": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/forms-input--types",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "inprogress",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Segmented Button": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-segmented-button--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Select Menu": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/forms-select-menu--select-menu",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "link": "/components/select/specs/",
-                    "name": "Component Tokens",
-                    "status": "available",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Sign In": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "name": "Web Component",
-                    "status": "unavailable",
-                    "type": "component",
-                    "version": "N/A"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Slider": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/forms-slider--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "link": "/components/slider/specs/",
-                    "name": "Component Tokens",
-                    "status": "available",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Status Symbol": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-status--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "inprogress",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Status System": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-status--all-variants",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "inprogress",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Switch": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-switch--switch-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Table": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-table--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "available",
-                    "type": "token",
-                    "version": "v7"
-                }
-            ]
-        },
-        "Tabs": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-tabs--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Tag": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-tag--rux-tag",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Textarea": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/forms-textarea--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "link": "/components/textarea/specs/",
-                    "name": "Component Tokens",
-                    "status": "available",
-                    "type": "token",
-                    "version": "v1"
-                }
-            ]
-        },
-        "Timeline": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/beta-timeline-beta--default-story",
-                    "name": "Web Component",
-                    "status": "inprogress",
-                    "type": "component",
-                    "version": "v6"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Tooltip": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-tooltip--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        },
-        "Tree": {
-            "assets": [
-                {
-                    "name": "Documentation",
-                    "status": "available",
-                    "type": "documentation",
-                    "version": "N/A"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
-                    "name": "UI Kit - Dark",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
-                    "name": "UI Kit - Light",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
-                    "name": "UI Kit - Wireframe",
-                    "status": "available",
-                    "type": "ui",
-                    "version": "v7"
-                },
-                {
-                    "link": "https://astro-components.netlify.app/?path=/story/components-tree--default-story",
-                    "name": "Web Component",
-                    "status": "available",
-                    "type": "component",
-                    "version": "v7"
-                },
-                {
-                    "name": "Component Tokens",
-                    "status": "planned",
-                    "type": "token",
-                    "version": "N/A"
-                }
-            ]
-        }
-    },
-    "general": {
-        "id": "asset-status",
-        "title": "Asset Status"
-    }
+	"$schema": "./asset-status.schema.json",
+	"data": {
+		"Accordion": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-accordion--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"All Options": {
+			"assets": [
+				{
+					"name": "Documentations",
+					"status": "available",
+					"type": "documentation",
+					"version": "v7"
+				},
+				{
+					"name": "UI Kit - Dark",
+					"status": "inprogress",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"name": "UI Kit - Light",
+					"status": "planned",
+					"type": "ui",
+					"version": "N/A"
+				},
+				{
+					"name": "Web Component",
+					"status": "unavailable",
+					"type": "component",
+					"version": "N/A"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "deprecated",
+					"type": "token",
+					"version": "v7"
+				}
+			]
+		},
+		"Application Feedback": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				}
+			]
+		},
+		"Breadcrumbs": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-breadcrumb--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Button": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-button--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"link": "/components/button/specs/",
+					"name": "Component Tokens",
+					"status": "available",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Card": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-card--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Checkbox": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/forms-checkbox-group--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Classification & Control Markings": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-classification-markings--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Clock": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-clock--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Container": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-container--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Data Visualization": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"name": "Web Component",
+					"status": "unavailable",
+					"type": "component",
+					"version": "N/A"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "inprogress",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Date Picker": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "N/A"
+				},
+				{
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "N/A"
+				},
+				{
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "N/A"
+				},
+				{
+					"name": "Web Component",
+					"status": "unavailable",
+					"type": "component",
+					"version": "N/A"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "unavailable",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Dialog": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-dialog--dialog",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Focus State": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Forms and Validation": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				}
+			]
+		},
+		"Global Status Bar": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-global-status-bar--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Icons and Symbols": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-monitoring-icon--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Input Field": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/forms-input--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"link": "/components/input-field/specs/",
+					"name": "Component Tokens",
+					"status": "available",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Link": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"name": "Web Component",
+					"status": "unavailable",
+					"type": "component",
+					"version": "N/A"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Log": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-log--log",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Modeless Panes": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				}
+			]
+		},
+		"Monitoring Icon": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-monitoring-icon--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Navigation": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				}
+			]
+		},
+		"Notification Banner": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-notification--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Notifications": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				}
+			]
+		},
+		"Pagination": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"name": "Web Component",
+					"status": "planned",
+					"type": "component",
+					"version": "N/A"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Pop Up": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-pop-up--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Pop Up Menu": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-pop-up--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Progress": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-progress--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Push Button": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-push-button--push-button",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Radio Button": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/forms-radio-group--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "inprogress",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Search": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/forms-input--types",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "inprogress",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Segmented Button": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-segmented-button--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Select Menu": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/forms-select-menu--select-menu",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"link": "/components/select/specs/",
+					"name": "Component Tokens",
+					"status": "available",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Sign In": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"name": "Web Component",
+					"status": "unavailable",
+					"type": "component",
+					"version": "N/A"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Slider": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/forms-slider--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"link": "/components/slider/specs/",
+					"name": "Component Tokens",
+					"status": "available",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Status Symbol": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-status--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "inprogress",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Status System": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-status--all-variants",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "inprogress",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Switch": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-switch--switch-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Table": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-table--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "available",
+					"type": "token",
+					"version": "v7"
+				}
+			]
+		},
+		"Tabs": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-tabs--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Tag": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-tag--rux-tag",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Textarea": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/forms-textarea--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"link": "/components/textarea/specs/",
+					"name": "Component Tokens",
+					"status": "available",
+					"type": "token",
+					"version": "v1"
+				}
+			]
+		},
+		"Timeline": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/beta-timeline-beta--default-story",
+					"name": "Web Component",
+					"status": "inprogress",
+					"type": "component",
+					"version": "v6"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Toast": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/beta-toast-beta--default-story",
+					"name": "Web Component",
+					"status": "inprogress",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Tooltip": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-tooltip--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		},
+		"Tree": {
+			"assets": [
+				{
+					"name": "Documentation",
+					"status": "available",
+					"type": "documentation",
+					"version": "N/A"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1157371532469023309/Astro-7-UXDS---Dark-Theme",
+					"name": "UI Kit - Dark",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203068683334364243/Astro-7-UXDS---Light-Theme",
+					"name": "UI Kit - Light",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://www.figma.com/community/file/1203487593021750781/Astro-7-UXDS---Wireframe-Theme",
+					"name": "UI Kit - Wireframe",
+					"status": "available",
+					"type": "ui",
+					"version": "v7"
+				},
+				{
+					"link": "https://astro-components.netlify.app/?path=/story/components-tree--default-story",
+					"name": "Web Component",
+					"status": "available",
+					"type": "component",
+					"version": "v7"
+				},
+				{
+					"name": "Component Tokens",
+					"status": "planned",
+					"type": "token",
+					"version": "N/A"
+				}
+			]
+		}
+	},
+	"general": {
+		"id": "asset-status",
+		"title": "Asset Status"
+	}
 }

--- a/src/data/component-playgrounds.record.json
+++ b/src/data/component-playgrounds.record.json
@@ -1686,10 +1686,7 @@
 					"kind": "menu",
 					"attribute": "strategy",
 					"property": "strategy",
-					"options": [
-						"absolute",
-						"fixed"
-					],
+					"options": ["absolute", "fixed"],
 					"value": "absolute"
 				}
 			],
@@ -2685,6 +2682,36 @@
 				}
 			],
 			"style": "rux-timeline { --normal-fill: #56f000; --standby-fill: #2dccff; --standby-border: #2dccff; --standby-fill-opacity: 0; --off-fill: #a4abb6; --off-border: #a4abb6; --critical-fill: #ff3838; --critical-border: #ff3838; --caution-fill: #fce83a; --caution-border: #fce83a; --serious-fill: #ffb302; --serious-border: #ffb302;}"
+		},
+		{
+			"tag": "rux-toast",
+			"constructor": "RuxToast",
+			"align": "center",
+			"examples": [
+				{
+					"name": "Default",
+					"code": "<rux-toast message=\"Toast\"></rux-toast>"
+				}
+			],
+			"fields": [
+				{
+					"kind": "text",
+					"property": "message",
+					"attribute": "message",
+					"value": "Toast"
+				},
+				{
+					"kind": "text",
+					"property": "close-after",
+					"attribute": "close-after"
+				},
+				{
+					"kind": "switch",
+					"property": "hideClose",
+					"attribute": "hideClose",
+					"checked": false
+				}
+			]
 		},
 		{
 			"tag": "rux-tooltip",

--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -1,372 +1,376 @@
 [
-    {
-        "items": [
-            {
-                "label": "Getting Started",
-                "url": "/getting-started/"
-            },
-            {
-                "label": "Designers",
-                "url": "/getting-started/designers/"
-            },
-            {
-                "label": "Developers",
-                "url": "/getting-started/developers/"
-            }
-        ],
-        "label": "Getting Started"
-    },
-    {
-        "items": [
-            {
-                "label": "Getting Started",
-                "url": "/design-tokens/getting-started/"
-            },
-            {
-                "label": "Installation",
-                "url": "/design-tokens/installation/"
-            },
-            {
-                "label": "Reference",
-                "url": "/design-tokens/reference/"
-            },
-            {
-                "label": "System",
-                "url": "/design-tokens/system/"
-            },
-            {
-                "label": "Component",
-                "url": "/design-tokens/component/"
-            }
-        ],
-        "label": "Design Tokens"
-    },
-    {
-        "items": [
-            {
-                "label": "Typography",
-                "url": "/design-guidelines/typography/"
-            },
-            {
-                "label": "Theme",
-                "url": "/design-guidelines/theme/"
-            },
-            {
-                "label": "Grid",
-                "url": "/design-guidelines/grid/"
-            },
-            {
-                "label": "Glossary",
-                "url": "/design-guidelines/glossary/"
-            }
-        ],
-        "label": "Design Guidelines"
-    },
-    {
-        "items": [
-            {
-                "label": "Application Feedback",
-                "url": "/patterns/application-feedback/"
-            },
-            {
-                "label": "Breadcrumbs",
-                "url": "/patterns/breadcrumbs/"
-            },
-            {
-                "label": "Data Visualization",
-                "url": "/patterns/data-visualization/"
-            },
-            {
-                "label": "Focus State",
-                "url": "/patterns/focus/"
-            },
-            {
-                "label": "Forms and Validation",
-                "url": "/patterns/forms-and-validation/"
-            },
-            {
-                "label": "Modeless Panes",
-                "url": "/patterns/modeless-panes/"
-            },
-            {
-                "label": "Navigation",
-                "url": "/patterns/navigation/"
-            },
-            {
-                "label": "Notifications",
-                "url": "/patterns/notifications/"
-            },
-            {
-                "label": "Pop Up Menu",
-                "url": "/patterns/pop-up-menu/"
-            },
-            {
-                "label": "Sign In",
-                "url": "/patterns/sign-in/"
-            },
-            {
-                "label": "Status System",
-                "url": "/patterns/status-system/"
-            },
-            {
-                "label": "Table",
-                "url": "/patterns/table/"
-            }
-        ],
-        "label": "Patterns"
-    },
-    {
-        "items": [
-            {
-                "label": "Getting Started",
-                "url": "/components/getting-started/"
-            },
-            {
-                "label": "Component Sandbox",
-                "url": "/components/component-sandbox/"
-            },
-            {
-                "label": "separator",
-                "url": "/separator"
-            },
-            {
-                "label": "Accordion",
-                "url": "/components/accordion/"
-            },
-            {
-                "label": "Application State",
-                "url": "/components/application-state/"
-            },
-            {
-                "label": "Button",
-                "url": "/components/button/"
-            },
-            {
-                "label": "Card",
-                "url": "/components/card/"
-            },
-            {
-                "label": "Checkbox",
-                "url": "/components/checkbox/"
-            },
-            {
-                "label": "Classification Markings",
-                "url": "/components/classification-markings/"
-            },
-            {
-                "label": "Clock",
-                "url": "/components/clock/"
-            },
-            {
-                "label": "Container",
-                "url": "/components/container/"
-            },
-            {
-                "label": "Date Picker",
-                "url": "/components/date-picker/"
-            },
-            {
-                "label": "Dialog",
-                "url": "/components/dialog/"
-            },
-            {
-                "label": "Global Status Bar",
-                "url": "/components/global-status-bar/"
-            },
-            {
-                "label": "Icons and Symbols",
-                "url": "/components/icons-and-symbols/"
-            },
-            {
-                "label": "Input Field",
-                "url": "/components/input-field/"
-            },
-            {
-                "label": "Link",
-                "url": "/components/link/"
-            },
-            {
-                "label": "Log",
-                "url": "/components/log/"
-            },
-            {
-                "label": "Notification Banner",
-                "url": "/components/notification-banner/"
-            },
-            {
-                "label": "Pagination",
-                "url": "/components/pagination/"
-            },
-            {
-                "label": "Pop Up",
-                "url": "/components/pop-up/"
-            },
-            {
-                "label": "Progress",
-                "url": "/components/progress/"
-            },
-            {
-                "label": "Push Button",
-                "url": "/components/push-button/"
-            },
-            {
-                "label": "Radio Button",
-                "url": "/components/radio-button/"
-            },
-            {
-                "label": "Search",
-                "url": "/components/search/"
-            },
-            {
-                "label": "Segmented Button",
-                "url": "/components/segmented-button/"
-            },
-            {
-                "label": "Select",
-                "url": "/components/select/"
-            },
-            {
-                "label": "Slider",
-                "url": "/components/slider/"
-            },
-            {
-                "label": "Status Symbol",
-                "url": "/components/status-symbol/"
-            },
-            {
-                "label": "Switch",
-                "url": "/components/switch/"
-            },
-            {
-                "label": "Tabs",
-                "url": "/components/tabs/"
-            },
-            {
-                "label": "Tag",
-                "url": "/components/tag/"
-            },
-            {
-                "label": "Textarea",
-                "url": "/components/textarea/"
-            },
-            {
-                "label": "Timeline",
-                "url": "/components/timeline/"
-            },
-            {
-                "label": "Tooltip",
-                "url": "/components/tooltip/"
-            },
-            {
-                "label": "Tree",
-                "url": "/components/tree/"
-            }
-        ],
-        "label": "Components"
-    },
-    {
-        "label": "Icon Library",
-        "url": "/icon-library/"
-    },
-    {
-        "items": [
-            {
-                "label": "Research",
-                "url": "/design-process/research/"
-            },
-            {
-                "label": "UI Design",
-                "url": "/design-process/ui-design/"
-            },
-            {
-                "label": "Visual Design",
-                "url": "/design-process/visual-design/"
-            },
-            {
-                "label": "UX Assessments",
-                "url": "/design-process/ux-assessments/"
-            }
-        ],
-        "label": "Design Process"
-    },
-    {
-        "items": [
-            {
-                "label": "Service Specific UX Design",
-                "url": "/service-specific-ux-design/"
-            },
-            {
-                "label": "GRM Service UX Design",
-                "url": "/grm-service-ux-design/about-the-grm-designs/"
-            },
-            {
-                "label": "TT&C Service UX Design",
-                "url": "/ttc-service-ux-design/about-the-ttc-designs/"
-            },
-            {
-                "label": "FD Service UX Design",
-                "url": "/fd-service-ux-design/about-the-fd-designs/"
-            }
-        ],
-        "label": "Case Studies"
-    },
-    {
-        "items": [
-            {
-                "label": "Astro for Apple",
-                "url": "/platforms/astro-for-apple/"
-            },
-            {
-                "label": "Astro for Grafana",
-                "url": "/platforms/astro-for-grafana/"
-            },
-            {
-                "label": "Astro for R2C2",
-                "url": "/platforms/astro-for-r2c2/"
-            }
-        ],
-        "label": "Platforms"
-    },
-    {
-        "items": [
-            {
-                "label": "Propose a Change",
-                "url": "/community/propose-a-change/"
-            },
-            {
-                "label": "Content Policy",
-                "url": "/community/content-policy/"
-            }
-        ],
-        "label": "Community"
-    },
-    {
-        "items": [
-            {
-                "label": "R2C2 Design Compliance",
-                "url": "/compliance/r2c2-design-compliance/"
-            },
-            {
-                "label": "MIL-STD 1472H",
-                "url": "/compliance/mil-std-1472/"
-            }
-        ],
-        "label": "Compliance"
-    },
-    {
-        "label": "Releases",
-        "url": "/releases/"
-    },
-    {
-        "label": "Migration",
-        "url": "/migration/"
-    },
-    {
-        "label": "Downloads",
-        "url": "/downloads/"
-    },
-    {
-        "label": "Support",
-        "url": "/support/"
-    }
+	{
+		"items": [
+			{
+				"label": "Getting Started",
+				"url": "/getting-started/"
+			},
+			{
+				"label": "Designers",
+				"url": "/getting-started/designers/"
+			},
+			{
+				"label": "Developers",
+				"url": "/getting-started/developers/"
+			}
+		],
+		"label": "Getting Started"
+	},
+	{
+		"items": [
+			{
+				"label": "Getting Started",
+				"url": "/design-tokens/getting-started/"
+			},
+			{
+				"label": "Installation",
+				"url": "/design-tokens/installation/"
+			},
+			{
+				"label": "Reference",
+				"url": "/design-tokens/reference/"
+			},
+			{
+				"label": "System",
+				"url": "/design-tokens/system/"
+			},
+			{
+				"label": "Component",
+				"url": "/design-tokens/component/"
+			}
+		],
+		"label": "Design Tokens"
+	},
+	{
+		"items": [
+			{
+				"label": "Typography",
+				"url": "/design-guidelines/typography/"
+			},
+			{
+				"label": "Theme",
+				"url": "/design-guidelines/theme/"
+			},
+			{
+				"label": "Grid",
+				"url": "/design-guidelines/grid/"
+			},
+			{
+				"label": "Glossary",
+				"url": "/design-guidelines/glossary/"
+			}
+		],
+		"label": "Design Guidelines"
+	},
+	{
+		"items": [
+			{
+				"label": "Application Feedback",
+				"url": "/patterns/application-feedback/"
+			},
+			{
+				"label": "Breadcrumbs",
+				"url": "/patterns/breadcrumbs/"
+			},
+			{
+				"label": "Data Visualization",
+				"url": "/patterns/data-visualization/"
+			},
+			{
+				"label": "Focus State",
+				"url": "/patterns/focus/"
+			},
+			{
+				"label": "Forms and Validation",
+				"url": "/patterns/forms-and-validation/"
+			},
+			{
+				"label": "Modeless Panes",
+				"url": "/patterns/modeless-panes/"
+			},
+			{
+				"label": "Navigation",
+				"url": "/patterns/navigation/"
+			},
+			{
+				"label": "Notifications",
+				"url": "/patterns/notifications/"
+			},
+			{
+				"label": "Pop Up Menu",
+				"url": "/patterns/pop-up-menu/"
+			},
+			{
+				"label": "Sign In",
+				"url": "/patterns/sign-in/"
+			},
+			{
+				"label": "Status System",
+				"url": "/patterns/status-system/"
+			},
+			{
+				"label": "Table",
+				"url": "/patterns/table/"
+			}
+		],
+		"label": "Patterns"
+	},
+	{
+		"items": [
+			{
+				"label": "Getting Started",
+				"url": "/components/getting-started/"
+			},
+			{
+				"label": "Component Sandbox",
+				"url": "/components/component-sandbox/"
+			},
+			{
+				"label": "separator",
+				"url": "/separator"
+			},
+			{
+				"label": "Accordion",
+				"url": "/components/accordion/"
+			},
+			{
+				"label": "Application State",
+				"url": "/components/application-state/"
+			},
+			{
+				"label": "Button",
+				"url": "/components/button/"
+			},
+			{
+				"label": "Card",
+				"url": "/components/card/"
+			},
+			{
+				"label": "Checkbox",
+				"url": "/components/checkbox/"
+			},
+			{
+				"label": "Classification Markings",
+				"url": "/components/classification-markings/"
+			},
+			{
+				"label": "Clock",
+				"url": "/components/clock/"
+			},
+			{
+				"label": "Container",
+				"url": "/components/container/"
+			},
+			{
+				"label": "Date Picker",
+				"url": "/components/date-picker/"
+			},
+			{
+				"label": "Dialog",
+				"url": "/components/dialog/"
+			},
+			{
+				"label": "Global Status Bar",
+				"url": "/components/global-status-bar/"
+			},
+			{
+				"label": "Icons and Symbols",
+				"url": "/components/icons-and-symbols/"
+			},
+			{
+				"label": "Input Field",
+				"url": "/components/input-field/"
+			},
+			{
+				"label": "Link",
+				"url": "/components/link/"
+			},
+			{
+				"label": "Log",
+				"url": "/components/log/"
+			},
+			{
+				"label": "Notification Banner",
+				"url": "/components/notification-banner/"
+			},
+			{
+				"label": "Pagination",
+				"url": "/components/pagination/"
+			},
+			{
+				"label": "Pop Up",
+				"url": "/components/pop-up/"
+			},
+			{
+				"label": "Progress",
+				"url": "/components/progress/"
+			},
+			{
+				"label": "Push Button",
+				"url": "/components/push-button/"
+			},
+			{
+				"label": "Radio Button",
+				"url": "/components/radio-button/"
+			},
+			{
+				"label": "Search",
+				"url": "/components/search/"
+			},
+			{
+				"label": "Segmented Button",
+				"url": "/components/segmented-button/"
+			},
+			{
+				"label": "Select",
+				"url": "/components/select/"
+			},
+			{
+				"label": "Slider",
+				"url": "/components/slider/"
+			},
+			{
+				"label": "Status Symbol",
+				"url": "/components/status-symbol/"
+			},
+			{
+				"label": "Switch",
+				"url": "/components/switch/"
+			},
+			{
+				"label": "Tabs",
+				"url": "/components/tabs/"
+			},
+			{
+				"label": "Tag",
+				"url": "/components/tag/"
+			},
+			{
+				"label": "Textarea",
+				"url": "/components/textarea/"
+			},
+			{
+				"label": "Timeline",
+				"url": "/components/timeline/"
+			},
+			{
+				"label": "Toast",
+				"url": "/components/toast/"
+			},
+			{
+				"label": "Tooltip",
+				"url": "/components/tooltip/"
+			},
+			{
+				"label": "Tree",
+				"url": "/components/tree/"
+			}
+		],
+		"label": "Components"
+	},
+	{
+		"label": "Icon Library",
+		"url": "/icon-library/"
+	},
+	{
+		"items": [
+			{
+				"label": "Research",
+				"url": "/design-process/research/"
+			},
+			{
+				"label": "UI Design",
+				"url": "/design-process/ui-design/"
+			},
+			{
+				"label": "Visual Design",
+				"url": "/design-process/visual-design/"
+			},
+			{
+				"label": "UX Assessments",
+				"url": "/design-process/ux-assessments/"
+			}
+		],
+		"label": "Design Process"
+	},
+	{
+		"items": [
+			{
+				"label": "Service Specific UX Design",
+				"url": "/service-specific-ux-design/"
+			},
+			{
+				"label": "GRM Service UX Design",
+				"url": "/grm-service-ux-design/about-the-grm-designs/"
+			},
+			{
+				"label": "TT&C Service UX Design",
+				"url": "/ttc-service-ux-design/about-the-ttc-designs/"
+			},
+			{
+				"label": "FD Service UX Design",
+				"url": "/fd-service-ux-design/about-the-fd-designs/"
+			}
+		],
+		"label": "Case Studies"
+	},
+	{
+		"items": [
+			{
+				"label": "Astro for Apple",
+				"url": "/platforms/astro-for-apple/"
+			},
+			{
+				"label": "Astro for Grafana",
+				"url": "/platforms/astro-for-grafana/"
+			},
+			{
+				"label": "Astro for R2C2",
+				"url": "/platforms/astro-for-r2c2/"
+			}
+		],
+		"label": "Platforms"
+	},
+	{
+		"items": [
+			{
+				"label": "Propose a Change",
+				"url": "/community/propose-a-change/"
+			},
+			{
+				"label": "Content Policy",
+				"url": "/community/content-policy/"
+			}
+		],
+		"label": "Community"
+	},
+	{
+		"items": [
+			{
+				"label": "R2C2 Design Compliance",
+				"url": "/compliance/r2c2-design-compliance/"
+			},
+			{
+				"label": "MIL-STD 1472H",
+				"url": "/compliance/mil-std-1472/"
+			}
+		],
+		"label": "Compliance"
+	},
+	{
+		"label": "Releases",
+		"url": "/releases/"
+	},
+	{
+		"label": "Migration",
+		"url": "/migration/"
+	},
+	{
+		"label": "Downloads",
+		"url": "/downloads/"
+	},
+	{
+		"label": "Support",
+		"url": "/support/"
+	}
 ]

--- a/src/pages/components/card.md
+++ b/src/pages/components/card.md
@@ -8,8 +8,9 @@ git: rux-card
 assets:
   name: Card
 sandbox:
-  style: "--y: 200px;"
+  style: '--y: 200px;'
 ---
+
 ## Interactive Example
 
 ::tag{ is=a-playground tag=rux-card }
@@ -18,17 +19,17 @@ A card is a container for a few short, related pieces of information. It roughly
 
 ## Rules of Thumb
 
-Limit actions on a card. Actions should be simple, direct, and predictable. Actions should clearly indicate what will happen when selected.
+- Limit actions on a card. Actions should be simple, direct, and predictable. Actions should clearly indicate what will happen when selected.
 
-Display content with a logical hierarchy, setting clear prioritization of content.
+- Display content with a logical hierarchy, setting clear prioritization of content.
 
-Cards should be self-contained, without relying on surrounding elements for context. It cannot be merged, divided, or split.
+- Cards should be self-contained, without relying on surrounding elements for context. It cannot be merged, divided, or split.
 
-Copy should be scannable; content is crisp, brief, and focused. Actionable language is preferred. Passive voice should be avoided.
+- Copy should be scannable; content is crisp, brief, and focused. Actionable language is preferred. Passive voice should be avoided.
 
-Identify “Hero content”, but limit them to 1-2 elements. These draw attention.
+- Identify “Hero content”, but limit them to 1-2 elements. These draw attention.
 
-Content should be actionable. Structured with visual hierarchy to bring prominence to important content. Be clear about content that requires user action.
+- Content should be actionable. Structured with visual hierarchy to bring prominence to important content. Be clear about content that requires user action.
 
 ## Appearance and Behavior
 
@@ -51,12 +52,12 @@ Use sentence case unless an extenuating circumstance arises.
 
 :::two-col
 
-![Do: Group content that is short and scannable with obvious hero content and a clear action item.](/img/components/card/card-do-1.webp "Do: Group content that is short and scannable with obvious hero content and a clear action item.")
+![Do: Group content that is short and scannable with obvious hero content and a clear action item.](/img/components/card/card-do-1.webp 'Do: Group content that is short and scannable with obvious hero content and a clear action item.')
 
-![Don’t: Clutter the card with long blocks of text, multiple hero items, or any not easily scannable and un-actionable content where the purpose is unclear. ](/img/components/card/card-dont-1.webp "Don’t: Clutter the card with long blocks of text, multiple hero items, or any not easily scannable and un-actionable content where the purpose is unclear. ")
+![Don’t: Clutter the card with long blocks of text, multiple hero items, or any not easily scannable and un-actionable content where the purpose is unclear. ](/img/components/card/card-dont-1.webp 'Don’t: Clutter the card with long blocks of text, multiple hero items, or any not easily scannable and un-actionable content where the purpose is unclear. ')
 
-![Do: Keep cards in a container the same size, and cards used in similar contexts across the application a consistent size. ](/img/components/card/card-do-2.webp "Do: Keep cards in a container the same size, and cards used in similar contexts across the application a consistent size. ")
+![Do: Keep cards in a container the same size, and cards used in similar contexts across the application a consistent size. ](/img/components/card/card-do-2.webp 'Do: Keep cards in a container the same size, and cards used in similar contexts across the application a consistent size. ')
 
-![Don’t: Vary the size of cards in a group or container, or use different sized cards in similar situations across the application. ](/img/components/card/card-dont-2.webp "Don’t: Vary the size of cards in a group or container, or use different sized cards in similar situations across the application. ")
+![Don’t: Vary the size of cards in a group or container, or use different sized cards in similar situations across the application. ](/img/components/card/card-dont-2.webp 'Don’t: Vary the size of cards in a group or container, or use different sized cards in similar situations across the application. ')
 
 :::

--- a/src/pages/components/toast.md
+++ b/src/pages/components/toast.md
@@ -1,0 +1,51 @@
+---
+title: Toast
+description: Toasts are non-modal notifications that display a short message to the user.
+layout: project:layouts/component-docs/component-docs-layout.astro
+storybook: beta-toast-beta--default-story
+height: 216px
+git: rux-toast
+assets:
+  name: Toast
+---
+
+## Interactive Example
+
+::tag{ is=a-playground tag=rux-toast }
+
+## Rules of Thumb
+
+- Use Toasts when the system needs to provide feedback about a user action or system status.
+- Toasts should only be used for simple notifications, confirmations, and low-priority alerts.
+- Toast messages should contain no more than one to two lines of text.
+- Don’t change the background color of a Toast; it should be unobtrusive.
+
+## Appearance and Behavior
+
+Toast notifications attract a user’s attention without forcing the user to interact with the message as they can dismiss on a timer. Toast messages solve the problem of users needing a less critical type of message notification than a notification banner, badge, or modal. This offers users more flexibility for displaying different kinds of messages that may need attention related to system or user feedback.
+
+Toasts consist of a simple rectangular pop up and a message. Alternatively, toasts may also contain icons, such as a close button for non-dismissible toasts, and links. Toasts can auto-dismiss after displaying for a brief time on the screen.
+
+### Placement
+
+Toasts typically slide in and out of the top right side of the desktop screen and should be displayed below Monitoring Icons if those are being used in the status bar. Toasts can also be displayed at the bottom (left or right) or top center of the desktop screen.
+
+### Dismissible Toast
+
+A Dismissible Toast is a type of toast message with actionable content which persists until an action is taken or it is dismissed by the user.
+
+### Toast Stack
+
+The Toast Stack is a group of toasts displayed in a vertical arrangement. New toast notifications appear at the top of the Toast Stack and push older stacks down.
+
+## Examples
+
+:::two-col
+
+![Do: Stack multiple toasts vertically, with the most recent appearing at the top of the list.](/img/patterns/notifications/notifications-toast-do-1.webp 'Do: Stack multiple toasts vertically, with the most recent appearing at the top of the list.')
+
+![Don’t: Place toasts over interface elements which need to remain visible like Monitoring Icons. ](/img/patterns/notifications/notifications-toast-dont-1.webp 'Place toasts over interface elements which need to remain visible like Monitoring Icons.')
+
+![Don’t: Stack more than four toasts when possible. When there are more than that, visible toasts should be dismissed before any additional toasts appear. ](/img/patterns/notifications/notifications-toast-dont-2.webp 'Don’t: Stack more than four toasts when possible. When there are more than that, visible toasts should be dismissed before any additional toasts appear. ')
+
+:::


### PR DESCRIPTION
Adds the toast page, updates component playground with toast, and updates a very small issue I found on card where the rules of thumb were not list-items. 

Ticket: https://rocketcom.atlassian.net/browse/ASTRO-6427

I'm not sure if we need to have toast-stack as part of the playground or not? It looks fine, but I'm worried that a dev may not know about it and just use toast by itself based on this page. 
Also, should we call out that it's technically in beta? 