### PR TITLE
test fix for files

### DIFF
--- a/src/components/contribution-footer/contribution-footer.astro
+++ b/src/components/contribution-footer/contribution-footer.astro
@@ -3,7 +3,6 @@ import './contribution-footer.css'
 
 const { props } = Astro
 const githubURL = props.sourceurl
-console.log(props)
 ---
 <footer id="contribution-footer" class="p-contribution-footer">
 	<a href="#contribution-footer" class="h h3">

--- a/src/components/contribution-footer/contribution-footer.astro
+++ b/src/components/contribution-footer/contribution-footer.astro
@@ -3,6 +3,7 @@ import './contribution-footer.css'
 
 const { props } = Astro
 const githubURL = props.sourceurl
+console.log(props)
 ---
 <footer id="contribution-footer" class="p-contribution-footer">
 	<a href="#contribution-footer" class="h h3">

--- a/src/layouts/docs/docs-layout.astro
+++ b/src/layouts/docs/docs-layout.astro
@@ -43,13 +43,13 @@ const withoutTrailingSlash = (value: string) => value.replace(matchTrailingSlash
 
 /* grab the source file url and then get the extension */
 const fileURL = new URL(Astro.props.file!, 'file:').toString()
-const fileExt = fileURL.split('.').at(-1)
+let fileExt = fileURL.split('.').at(-1)
 
 /* test the file name against the file URL */
 const fileNoExt = fileURL.split('.').at(0)
 const fileName = fileNoExt?.split('/').at(-1)
 const finalURLSeg = withoutTrailingSlash(Astro.url.pathname).split('/').at(-1)
-const gitURL = fileName !== finalURLSeg ? `${Astro.url.pathname}${fileName}.${fileExt}` : `${withoutTrailingSlash(Astro.url.pathname)}.${fileExt}`
+const gitURL = fileName !== finalURLSeg ? `${Astro.url.pathname}${fileName}.${fileExt === 'mjs' ? 'astro' : fileExt}` : `${withoutTrailingSlash(Astro.url.pathname)}.${fileExt === 'mjs' ? 'astro' : fileExt}`
 
 /** URL to the current source for this page. */
 const githubSourceURL = `${globalData.designSystem.repository}/tree/${globalData.designSystem.repositoryBranch}/src/pages${gitURL}`


### PR DESCRIPTION
[ASTRO-6474](https://rocketcom.atlassian.net/browse/ASTRO-6474)

I think something changed in a recent AstroJS update (as stuff tends to do). During the site build process all astro files get changed into mjs files. This apparently happens BEFORE the script I wrote to grab their file extensions as part of the GitHub url link. So I added a small hack to say that if the fileExtension is 'mjs' use 'astro' in the link instead.

That seems to have fixed it everywhere it was an issue.