### PR TITLE
add descriptions to specs pages missing them

### DIFF
--- a/src/pages/components/card/specs.astro
+++ b/src/pages/components/card/specs.astro
@@ -4,7 +4,7 @@ import TokenSpecTable from 'project:components/token-spec-table/token-spec-table
 import Heading from 'project:components/astro-headings/heading.astro';
 ---
 
-<ComponentDocsLayout content={{ title: 'Card' }}>
+<ComponentDocsLayout content={{ title: 'Card', description: 'A “card” is a UI design pattern that groups related information in a flexible-size container visually resembling a playing card. Within the Astro system, card sits on top of a container.' }}>
 	<Heading type="h2" title="Anatomy" />
 
 	<div class="spec-container -anatomy">

--- a/src/pages/components/log/specs.astro
+++ b/src/pages/components/log/specs.astro
@@ -4,7 +4,7 @@ import TokenSpecTable from 'project:components/token-spec-table/token-spec-table
 import Heading from 'project:components/astro-headings/heading.astro';
 ---
 
-<ComponentDocsLayout content={{ title: 'Log' }}>
+<ComponentDocsLayout content={{ title: 'Log', description: 'A Log is a tabular representation of application events and may include username, priority, equipment type, signal type, etc. As part of the Notification System, Logs provide sorting and filtering function for examining events.' }}>
 	<Heading type="h2" title="Anatomy" />
 
 	<div class="spec-container -anatomy">

--- a/src/pages/components/push-button/specs.astro
+++ b/src/pages/components/push-button/specs.astro
@@ -4,7 +4,7 @@ import TokenSpecTable from 'project:components/token-spec-table/token-spec-table
 import Heading from 'project:components/astro-headings/heading.astro';
 ---
 
-<ComponentDocsLayout content={{ title: 'Push Button' }}>
+<ComponentDocsLayout content={{ title: 'Push Button', description: 'Push Buttons are a variant of the Switch that incorporate label and action into a single user interface element. Push Buttons may provide a useful interface element where screen real-estate is at a premium.' }}>
 	<Heading type="h2" title="Anatomy" />
 
 	<div class="spec-container -anatomy">

--- a/src/pages/components/tag/specs.astro
+++ b/src/pages/components/tag/specs.astro
@@ -4,7 +4,7 @@ import TokenSpecTable from 'project:components/token-spec-table/token-spec-table
 import Heading from 'project:components/astro-headings/heading.astro';
 ---
 
-<ComponentDocsLayout content={{ title: 'Tag' }}>
+<ComponentDocsLayout content={{ title: 'Tag', description: 'A Tag is a component made up of a text label, container, and color. Tags help users quickly identify important information related to an item and categorize items by keywords.' }}>
 	<Heading type="h2" title="Anatomy" />
 
 	<div class="spec-container -anatomy">


### PR DESCRIPTION
Some of the specs pages were missing their descriptions. Probably happened when we switched them too .astro I've added them back. :)