### PR TITLE
fix: update currentURL passed into feedback widget

### DIFF
--- a/src/layouts/docs/docs-layout.astro
+++ b/src/layouts/docs/docs-layout.astro
@@ -32,7 +32,6 @@ const tabTitle = content.title
 const description = content.description || false
 const url = content.url
 const draft = content.draft ? content.draft : false
-
 /* Create github link to source file */
 
 /** RegEx to match a slash (/) at the end ($) of a string. */
@@ -97,7 +96,7 @@ const githubSourceURL = `${globalData.designSystem.repository}/tree/${globalData
 			</aside>
 		</div>
 	</main>
-	<FeedbackWidget currentURL={url} />
+	<FeedbackWidget currentURL={Astro.url.pathname} />
 </Layout>
 <script>
 	import './docs-layout.client'


### PR DESCRIPTION
When on a non-nested page like `/icon-library`, the `url` being passed as props to the feedback widget would be null. To fix this, I'm simply passing in `Astro.url.pathname`, which will pass the correct URL to the widget. 

I hit some ESLint crap that didn't make sense to me, so I pushed this up with `-n`. I'll notate the line where the issue occurred so we can verify it's fine. 