### PR TITLE
Fix DIW-125 Feedback Widget Overlapped By Icon Search Bar

### DIFF
--- a/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
+++ b/src/components/feedback-widgets/feedback-widget-sticky/feedback-widget.css
@@ -14,6 +14,7 @@
 
 	/* Appearance */
 	position: sticky;
+	z-index: 10;
 
 	@media (width < 1024px) {
 		/* Layout */


### PR DESCRIPTION
See a z-index on the feedback widget to stop the icon search bar from overlapping it.

![Screenshot 2024-08-28 at 9 56 08 AM](https://github.com/user-attachments/assets/90ad8f75-b829-4a7c-bacc-ce5b379a4165)
