### PR TITLE
Update Icon Set Name for Material Icons

### DIFF
--- a/src/pages/icon-library/index.astro
+++ b/src/pages/icon-library/index.astro
@@ -25,7 +25,7 @@ import IconCategories from 'project:components/icon-search/parts/search-categori
 		<small>
 			Icons in the Astro category have been custom-built by <a href="/getting-started/#astro-licensing">Rocket Communications</a> for users of Astro.
 			<br />
-			All non-Astro icons come from the <a href="https://fonts.google.com/icons?icon.style=Filled&icon.set=Material+Icons">Material Design Icons</a> set licensed by <a href="https://github.com/google/material-design-icons/blob/master/LICENSE">Google</a>.
+			All non-Astro icons come from the <a href="https://fonts.google.com/icons?icon.style=Filled&icon.set=Material+Icons">Material Icons</a> set licensed by <a href="https://github.com/google/material-design-icons/blob/master/LICENSE">Google</a>.
 		</small>
 	</p>
 


### PR DESCRIPTION
Since we put up this description, Google has clarified their old icons as "Material Icons" and now a different set of icons called "Material Design Icons" are online and available. Changing the description to clarify that we're using the Material Icons here.