### PR TITLE
fix(rux-design-token-preview): copy to clipboard button fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -382,6 +382,7 @@
 			"resolved": "https://registry.npmjs.org/@astrouxds/documentation-components/-/documentation-components-0.0.16.tgz",
 			"integrity": "sha512-JT48RQpTlDbbJvvn3TUK2BGEKdQ+U+PBMpvH2HIZQ1ZLjt5Ltp1nG0B/BthDWCk37q8pNkEvhmiz+O/tSAeHXA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"lit": "^2.2.5"
 			}

--- a/package.json
+++ b/package.json
@@ -346,7 +346,6 @@
 		]
 	},
 	"dependencies": {
-	
 		"highlight.js": "11.8.0"
 	}
 }

--- a/src/pages/design-tokens/component/index.astro
+++ b/src/pages/design-tokens/component/index.astro
@@ -2,7 +2,7 @@
 import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 import { component, lookupProperty } from 'project:utils/tokens.js'
 import '../shared.css'
-import { RuxDesignTokenPreview } from '@astrouxds/documentation-components' 
+import { RuxDesignTokenPreview } from '@astrouxds/documentation-components'
 
 const title = 'Component Tokens'
 const description = 'Component specific tokens to be used only when rebuilding components.'
@@ -14,7 +14,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'button').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -32,7 +32,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'card').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -50,7 +50,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'checkbox').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -68,7 +68,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'classification-banner').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -86,7 +86,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'clock').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -104,7 +104,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'container').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -121,7 +121,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'gsb').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -139,7 +139,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'indeterminate-progress').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -157,7 +157,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'input').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -175,7 +175,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'link').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -193,7 +193,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'log').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -211,7 +211,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'menu').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -228,7 +228,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'monitoring-icon').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -246,7 +246,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'notification-banner').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -264,7 +264,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'progress').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -283,7 +283,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'radio').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -301,7 +301,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'scrollbar').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -319,7 +319,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'select').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -337,7 +337,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'slider').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -353,7 +353,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'status-symbol').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -371,7 +371,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'switch').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -388,7 +388,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'table').map((token) => (
 			<RuxDesignTokenPreview
-				client:visible
+				client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -405,7 +405,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'tag').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -422,7 +422,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'textarea').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -439,7 +439,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'timeline').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -455,7 +455,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	{
 		component('dark', 'tooltip').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}

--- a/src/pages/design-tokens/component/light.astro
+++ b/src/pages/design-tokens/component/light.astro
@@ -2,7 +2,7 @@
 import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 import { component, lookupProperty } from 'project:utils/tokens.js'
 import '../shared.css'
-import { RuxDesignTokenPreview } from '@astrouxds/documentation-components' 
+import { RuxDesignTokenPreview } from '@astrouxds/documentation-components'
 
 const title = 'Component Tokens'
 const description = 'Component specific tokens to be used only when rebuilding components.'
@@ -14,7 +14,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'button').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -32,7 +32,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'card').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -50,7 +50,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'checkbox').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -68,7 +68,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'classification-banner').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -86,7 +86,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'clock').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -104,7 +104,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'container').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -121,7 +121,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'gsb').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -139,7 +139,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'indeterminate-progress').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -157,7 +157,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'input').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -175,7 +175,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'link').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -193,7 +193,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'log').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -211,7 +211,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'menu').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -228,7 +228,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'monitoring-icon').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -246,7 +246,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'notification-banner').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -264,7 +264,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'progress').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -283,7 +283,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'radio').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -301,7 +301,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'scrollbar').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -319,7 +319,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'select').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -337,7 +337,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'slider').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -353,7 +353,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'status-symbol').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -371,7 +371,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'switch').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -389,7 +389,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'table').map((token) => (
 					<RuxDesignTokenPreview
-						client:visible
+						client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -400,14 +400,14 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			}
 			<hr />
 
-			
+
 			<h2 id="tag">
 				Tag
 			</h2>
 			{
 				component('light', 'tag').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -424,7 +424,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'textarea').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -441,7 +441,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'timeline').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -457,7 +457,7 @@ const description = 'Component specific tokens to be used only when rebuilding c
 			{
 				component('light', 'tooltip').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}

--- a/src/pages/design-tokens/reference/index.astro
+++ b/src/pages/design-tokens/reference/index.astro
@@ -1,7 +1,7 @@
 ---
 import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 import { reference, findByName } from 'project:utils/tokens.js'
-import { RuxDesignTokenPreview } from '@astrouxds/documentation-components' 
+import { RuxDesignTokenPreview } from '@astrouxds/documentation-components'
 
 const title = 'Reference'
 const description = 'Full catalog of Astro design tokens.'
@@ -14,7 +14,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'color').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -37,7 +37,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'fontSizes').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -55,7 +55,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'fontWeights').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -73,7 +73,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'borderRadius').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -91,7 +91,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'opacity').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -109,7 +109,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'borderWidth').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -137,7 +137,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'spacing').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -160,7 +160,7 @@ const description = 'Full catalog of Astro design tokens.'
 	{
 		reference('dark', 'lineHeights').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -184,7 +184,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Monospace-1
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-monospace-1-font-family')?.name}
 		value={findByName('font-monospace-1-font-family')?.value}
 		alias={findByName('font-monospace-1-font-family')?.referenceToken}
@@ -192,7 +192,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-monospace-1-font-size')?.name}
 		value={findByName('font-monospace-1-font-size')?.value}
 		alias={findByName('font-monospace-1-font-size')?.referenceToken}
@@ -200,7 +200,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-monospace-1-font-weight')?.name}
 		value={findByName('font-monospace-1-font-weight')?.value}
 		alias={findByName('font-monospace-1-font-weight')?.referenceToken}
@@ -208,7 +208,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-monospace-1-line-height')?.name}
 		value={findByName('font-monospace-1-line-height')?.value}
 		alias={findByName('font-monospace-1-line-height')?.referenceToken}
@@ -216,7 +216,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-monospace-1-letter-spacing')?.name}
 		value={findByName('font-monospace-1-letter-spacing')?.value}
 		alias={findByName('font-monospace-1-letter-spacing')?.referenceToken}
@@ -228,7 +228,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Display 1
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-1-font-family')?.name}
 		value={findByName('font-display-1-font-family')?.value}
 		alias={findByName('font-display-1-font-family')?.referenceToken}
@@ -236,7 +236,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-1-font-size')?.name}
 		value={findByName('font-display-1-font-size')?.value}
 		alias={findByName('font-display-1-font-size')?.referenceToken}
@@ -244,7 +244,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-1-font-weight')?.name}
 		value={findByName('font-display-1-font-weight')?.value}
 		alias={findByName('font-display-1-font-weight')?.referenceToken}
@@ -252,7 +252,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-1-line-height')?.name}
 		value={findByName('font-display-1-line-height')?.value}
 		alias={findByName('font-display-1-line-height')?.referenceToken}
@@ -260,7 +260,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-1-letter-spacing')?.name}
 		value={findByName('font-display-1-letter-spacing')?.value}
 		alias={findByName('font-display-1-letter-spacing')?.referenceToken}
@@ -272,7 +272,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Display 2
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-2-font-family')?.name}
 		value={findByName('font-display-2-font-family')?.value}
 		alias={findByName('font-display-2-font-family')?.referenceToken}
@@ -280,7 +280,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-2-font-size')?.name}
 		value={findByName('font-display-2-font-size')?.value}
 		alias={findByName('font-display-2-font-size')?.referenceToken}
@@ -288,7 +288,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-2-font-weight')?.name}
 		value={findByName('font-display-2-font-weight')?.value}
 		alias={findByName('font-display-2-font-weight')?.referenceToken}
@@ -296,7 +296,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-2-line-height')?.name}
 		value={findByName('font-display-2-line-height')?.value}
 		alias={findByName('font-display-2-line-height')?.referenceToken}
@@ -304,7 +304,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-display-2-letter-spacing')?.name}
 		value={findByName('font-display-2-letter-spacing')?.value}
 		alias={findByName('font-display-2-letter-spacing')?.referenceToken}
@@ -316,7 +316,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Heading 1
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-font-family')?.name}
 		value={findByName('font-heading-1-font-family')?.value}
 		alias={findByName('font-heading-1-font-family')?.referenceToken}
@@ -324,7 +324,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-font-size')?.name}
 		value={findByName('font-heading-1-font-size')?.value}
 		alias={findByName('font-heading-1-font-size')?.referenceToken}
@@ -332,7 +332,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-font-weight')?.name}
 		value={findByName('font-heading-1-font-weight')?.value}
 		alias={findByName('font-heading-1-font-weight')?.referenceToken}
@@ -340,7 +340,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-line-height')?.name}
 		value={findByName('font-heading-1-line-height')?.value}
 		alias={findByName('font-heading-1-line-height')?.referenceToken}
@@ -348,7 +348,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-letter-spacing')?.name}
 		value={findByName('font-heading-1-letter-spacing')?.value}
 		alias={findByName('font-heading-1-letter-spacing')?.referenceToken}
@@ -360,7 +360,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Heading 1 Bold
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-bold-font-family')?.name}
 		value={findByName('font-heading-1-bold-font-family')?.value}
 		alias={findByName('font-heading-1-bold-font-family')?.referenceToken}
@@ -368,7 +368,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-bold-font-size')?.name}
 		value={findByName('font-heading-1-bold-font-size')?.value}
 		alias={findByName('font-heading-1-bold-font-size')?.referenceToken}
@@ -376,7 +376,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-bold-font-weight')?.name}
 		value={findByName('font-heading-1-bold-font-weight')?.value}
 		alias={findByName('font-heading-1-bold-font-weight')?.referenceToken}
@@ -384,7 +384,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-bold-line-height')?.name}
 		value={findByName('font-heading-1-bold-line-height')?.value}
 		alias={findByName('font-heading-1-bold-line-height')?.referenceToken}
@@ -392,7 +392,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-1-bold-letter-spacing')?.name}
 		value={findByName('font-heading-1-bold-letter-spacing')?.value}
 		alias={findByName('font-heading-1-bold-letter-spacing')?.referenceToken}
@@ -404,7 +404,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Heading 2
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-2-font-family')?.name}
 		value={findByName('font-heading-2-font-family')?.value}
 		alias={findByName('font-heading-2-font-family')?.referenceToken}
@@ -412,7 +412,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-2-font-size')?.name}
 		value={findByName('font-heading-2-font-size')?.value}
 		alias={findByName('font-heading-2-font-size')?.referenceToken}
@@ -420,7 +420,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-2-font-weight')?.name}
 		value={findByName('font-heading-2-font-weight')?.value}
 		alias={findByName('font-heading-2-font-weight')?.referenceToken}
@@ -428,7 +428,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-2-line-height')?.name}
 		value={findByName('font-heading-2-line-height')?.value}
 		alias={findByName('font-heading-2-line-height')?.referenceToken}
@@ -436,7 +436,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-2-letter-spacing')?.name}
 		value={findByName('font-heading-2-letter-spacing')?.value}
 		alias={findByName('font-heading-2-letter-spacing')?.referenceToken}
@@ -448,7 +448,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Heading 3
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-3-font-family')?.name}
 		value={findByName('font-heading-3-font-family')?.value}
 		alias={findByName('font-heading-3-font-family')?.referenceToken}
@@ -456,7 +456,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-3-font-size')?.name}
 		value={findByName('font-heading-3-font-size')?.value}
 		alias={findByName('font-heading-3-font-size')?.referenceToken}
@@ -464,7 +464,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-3-font-weight')?.name}
 		value={findByName('font-heading-3-font-weight')?.value}
 		alias={findByName('font-heading-3-font-weight')?.referenceToken}
@@ -472,7 +472,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-3-line-height')?.name}
 		value={findByName('font-heading-3-line-height')?.value}
 		alias={findByName('font-heading-3-line-height')?.referenceToken}
@@ -480,7 +480,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-3-letter-spacing')?.name}
 		value={findByName('font-heading-3-letter-spacing')?.value}
 		alias={findByName('font-heading-3-letter-spacing')?.referenceToken}
@@ -492,7 +492,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Heading 4
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-4-font-family')?.name}
 		value={findByName('font-heading-4-font-family')?.value}
 		alias={findByName('font-heading-4-font-family')?.referenceToken}
@@ -500,7 +500,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-4-font-size')?.name}
 		value={findByName('font-heading-4-font-size')?.value}
 		alias={findByName('font-heading-4-font-size')?.referenceToken}
@@ -508,7 +508,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-4-font-weight')?.name}
 		value={findByName('font-heading-4-font-weight')?.value}
 		alias={findByName('font-heading-4-font-weight')?.referenceToken}
@@ -516,7 +516,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-4-line-height')?.name}
 		value={findByName('font-heading-4-line-height')?.value}
 		alias={findByName('font-heading-4-line-height')?.referenceToken}
@@ -524,7 +524,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-4-letter-spacing')?.name}
 		value={findByName('font-heading-4-letter-spacing')?.value}
 		alias={findByName('font-heading-4-letter-spacing')?.referenceToken}
@@ -536,7 +536,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Heading 5
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-5-font-family')?.name}
 		value={findByName('font-heading-5-font-family')?.value}
 		alias={findByName('font-heading-5-font-family')?.referenceToken}
@@ -544,7 +544,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-5-font-size')?.name}
 		value={findByName('font-heading-5-font-size')?.value}
 		alias={findByName('font-heading-5-font-size')?.referenceToken}
@@ -552,7 +552,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-5-font-weight')?.name}
 		value={findByName('font-heading-5-font-weight')?.value}
 		alias={findByName('font-heading-5-font-weight')?.referenceToken}
@@ -560,7 +560,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-5-line-height')?.name}
 		value={findByName('font-heading-5-line-height')?.value}
 		alias={findByName('font-heading-5-line-height')?.referenceToken}
@@ -568,7 +568,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-5-letter-spacing')?.name}
 		value={findByName('font-heading-5-letter-spacing')?.value}
 		alias={findByName('font-heading-5-letter-spacing')?.referenceToken}
@@ -580,7 +580,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Heading 6
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-6-font-family')?.name}
 		value={findByName('font-heading-6-font-family')?.value}
 		alias={findByName('font-heading-6-font-family')?.referenceToken}
@@ -588,7 +588,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-6-font-size')?.name}
 		value={findByName('font-heading-6-font-size')?.value}
 		alias={findByName('font-heading-6-font-size')?.referenceToken}
@@ -596,7 +596,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-6-font-weight')?.name}
 		value={findByName('font-heading-6-font-weight')?.value}
 		alias={findByName('font-heading-6-font-weight')?.referenceToken}
@@ -604,7 +604,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-6-line-height')?.name}
 		value={findByName('font-heading-6-line-height')?.value}
 		alias={findByName('font-heading-6-line-height')?.referenceToken}
@@ -612,7 +612,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-heading-6-letter-spacing')?.name}
 		value={findByName('font-heading-6-letter-spacing')?.value}
 		alias={findByName('font-heading-6-letter-spacing')?.referenceToken}
@@ -624,7 +624,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Body 1
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-font-family')?.name}
 		value={findByName('font-body-1-font-family')?.value}
 		alias={findByName('font-body-1-font-family')?.referenceToken}
@@ -632,7 +632,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-font-size')?.name}
 		value={findByName('font-body-1-font-size')?.value}
 		alias={findByName('font-body-1-font-size')?.referenceToken}
@@ -640,7 +640,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-font-weight')?.name}
 		value={findByName('font-body-1-font-weight')?.value}
 		alias={findByName('font-body-1-font-weight')?.referenceToken}
@@ -648,7 +648,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-line-height')?.name}
 		value={findByName('font-body-1-line-height')?.value}
 		alias={findByName('font-body-1-line-height')?.referenceToken}
@@ -656,7 +656,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-letter-spacing')?.name}
 		value={findByName('font-body-1-letter-spacing')?.value}
 		alias={findByName('font-body-1-letter-spacing')?.referenceToken}
@@ -668,7 +668,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Body 1 Bold
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-bold-font-family')?.name}
 		value={findByName('font-body-1-bold-font-family')?.value}
 		alias={findByName('font-body-1-bold-font-family')?.referenceToken}
@@ -676,7 +676,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-bold-font-size')?.name}
 		value={findByName('font-body-1-bold-font-size')?.value}
 		alias={findByName('font-body-1-bold-font-size')?.referenceToken}
@@ -684,7 +684,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-bold-font-weight')?.name}
 		value={findByName('font-body-1-bold-font-weight')?.value}
 		alias={findByName('font-body-1-bold-font-weight')?.referenceToken}
@@ -692,7 +692,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-bold-line-height')?.name}
 		value={findByName('font-body-1-bold-line-height')?.value}
 		alias={findByName('font-body-1-bold-line-height')?.referenceToken}
@@ -700,7 +700,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-1-bold-letter-spacing')?.name}
 		value={findByName('font-body-1-bold-letter-spacing')?.value}
 		alias={findByName('font-body-1-bold-letter-spacing')?.referenceToken}
@@ -712,7 +712,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Body 2
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-font-family')?.name}
 		value={findByName('font-body-2-font-family')?.value}
 		alias={findByName('font-body-2-font-family')?.referenceToken}
@@ -720,7 +720,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-font-size')?.name}
 		value={findByName('font-body-2-font-size')?.value}
 		alias={findByName('font-body-2-font-size')?.referenceToken}
@@ -728,7 +728,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-font-weight')?.name}
 		value={findByName('font-body-2-font-weight')?.value}
 		alias={findByName('font-body-2-font-weight')?.referenceToken}
@@ -736,7 +736,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-line-height')?.name}
 		value={findByName('font-body-2-line-height')?.value}
 		alias={findByName('font-body-2-line-height')?.referenceToken}
@@ -744,7 +744,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-letter-spacing')?.name}
 		value={findByName('font-body-2-letter-spacing')?.value}
 		alias={findByName('font-body-2-letter-spacing')?.referenceToken}
@@ -756,7 +756,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Body 2 Bold
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-bold-font-family')?.name}
 		value={findByName('font-body-2-bold-font-family')?.value}
 		alias={findByName('font-body-2-bold-font-family')?.referenceToken}
@@ -764,7 +764,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-bold-font-size')?.name}
 		value={findByName('font-body-2-bold-font-size')?.value}
 		alias={findByName('font-body-2-bold-font-size')?.referenceToken}
@@ -772,7 +772,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-bold-font-weight')?.name}
 		value={findByName('font-body-2-bold-font-weight')?.value}
 		alias={findByName('font-body-2-bold-font-weight')?.referenceToken}
@@ -780,7 +780,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-bold-line-height')?.name}
 		value={findByName('font-body-2-bold-line-height')?.value}
 		alias={findByName('font-body-2-bold-line-height')?.referenceToken}
@@ -788,7 +788,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-2-bold-letter-spacing')?.name}
 		value={findByName('font-body-2-bold-letter-spacing')?.value}
 		alias={findByName('font-body-2-bold-letter-spacing')?.referenceToken}
@@ -800,7 +800,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Body 3
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-font-family')?.name}
 		value={findByName('font-body-3-font-family')?.value}
 		alias={findByName('font-body-3-font-family')?.referenceToken}
@@ -808,7 +808,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-font-size')?.name}
 		value={findByName('font-body-3-font-size')?.value}
 		alias={findByName('font-body-3-font-size')?.referenceToken}
@@ -816,7 +816,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-font-weight')?.name}
 		value={findByName('font-body-3-font-weight')?.value}
 		alias={findByName('font-body-3-font-weight')?.referenceToken}
@@ -824,7 +824,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-line-height')?.name}
 		value={findByName('font-body-3-line-height')?.value}
 		alias={findByName('font-body-3-line-height')?.referenceToken}
@@ -832,7 +832,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-letter-spacing')?.name}
 		value={findByName('font-body-3-letter-spacing')?.value}
 		alias={findByName('font-body-3-letter-spacing')?.referenceToken}
@@ -844,7 +844,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Body 3 Bold
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-bold-font-family')?.name}
 		value={findByName('font-body-3-bold-font-family')?.value}
 		alias={findByName('font-body-3-bold-font-family')?.referenceToken}
@@ -852,7 +852,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-bold-font-size')?.name}
 		value={findByName('font-body-3-bold-font-size')?.value}
 		alias={findByName('font-body-3-bold-font-size')?.referenceToken}
@@ -860,7 +860,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-bold-font-weight')?.name}
 		value={findByName('font-body-3-bold-font-weight')?.value}
 		alias={findByName('font-body-3-bold-font-weight')?.referenceToken}
@@ -868,7 +868,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-bold-line-height')?.name}
 		value={findByName('font-body-3-bold-line-height')?.value}
 		alias={findByName('font-body-3-bold-line-height')?.referenceToken}
@@ -876,7 +876,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-body-3-bold-letter-spacing')?.name}
 		value={findByName('font-body-3-bold-letter-spacing')?.value}
 		alias={findByName('font-body-3-bold-letter-spacing')?.referenceToken}
@@ -888,7 +888,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Control Body 1
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-font-family')?.name}
 		value={findByName('font-control-body-1-font-family')?.value}
 		alias={findByName('font-control-body-1-font-family')?.referenceToken}
@@ -896,7 +896,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-font-size')?.name}
 		value={findByName('font-control-body-1-font-size')?.value}
 		alias={findByName('font-control-body-1-font-size')?.referenceToken}
@@ -904,7 +904,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-font-weight')?.name}
 		value={findByName('font-control-body-1-font-weight')?.value}
 		alias={findByName('font-control-body-1-font-weight')?.referenceToken}
@@ -912,7 +912,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-line-height')?.name}
 		value={findByName('font-control-body-1-line-height')?.value}
 		alias={findByName('font-control-body-1-line-height')?.referenceToken}
@@ -920,7 +920,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-letter-spacing')?.name}
 		value={findByName('font-control-body-1-letter-spacing')?.value}
 		alias={findByName('font-control-body-1-letter-spacing')?.referenceToken}
@@ -932,7 +932,7 @@ const description = 'Full catalog of Astro design tokens.'
 		Control Body 1 Bold
 	</h3>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-bold-font-family')?.name}
 		value={findByName('font-control-body-1-bold-font-family')?.value}
 		alias={findByName('font-control-body-1-bold-font-family')?.referenceToken}
@@ -940,7 +940,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-family"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-bold-font-size')?.name}
 		value={findByName('font-control-body-1-bold-font-size')?.value}
 		alias={findByName('font-control-body-1-bold-font-size')?.referenceToken}
@@ -948,7 +948,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-size"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-bold-font-weight')?.name}
 		value={findByName('font-control-body-1-bold-font-weight')?.value}
 		alias={findByName('font-control-body-1-bold-font-weight')?.referenceToken}
@@ -956,7 +956,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="font-weight"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-bold-line-height')?.name}
 		value={findByName('font-control-body-1-bold-line-height')?.value}
 		alias={findByName('font-control-body-1-bold-line-height')?.referenceToken}
@@ -964,7 +964,7 @@ const description = 'Full catalog of Astro design tokens.'
 		type="line-height"
 	/>
 	<RuxDesignTokenPreview
-    client:visible
+    client:load
 		name={findByName('font-control-body-1-bold-letter-spacing')?.name}
 		value={findByName('font-control-body-1-bold-letter-spacing')?.value}
 		alias={findByName('font-control-body-1-bold-letter-spacing')?.referenceToken}

--- a/src/pages/design-tokens/system/index.astro
+++ b/src/pages/design-tokens/system/index.astro
@@ -2,7 +2,7 @@
 import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 import { system } from 'project:utils/tokens.js'
 import '../shared.css'
-import { RuxDesignTokenPreview } from '@astrouxds/documentation-components' 
+import { RuxDesignTokenPreview } from '@astrouxds/documentation-components'
 
 const title = 'System Tokens'
 const description = 'Tokens representing Astro semantic design decisions.'
@@ -14,7 +14,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	{
 		system('dark', 'color', 'background').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -32,7 +32,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	{
 		system('dark', 'color', 'text').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -50,7 +50,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	{
 		system('dark', 'color', 'border').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -68,7 +68,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	{
 		system('dark', 'color', 'status').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -86,7 +86,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	{
 		system('dark', 'color', 'classification').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -101,7 +101,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	{
 		system('dark', 'color', 'data-visualization').map((token) => (
 			<RuxDesignTokenPreview
-    client:visible
+    client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}

--- a/src/pages/design-tokens/system/light.astro
+++ b/src/pages/design-tokens/system/light.astro
@@ -2,7 +2,7 @@
 import DocsLayout from 'project:layouts/docs/docs-layout.astro'
 import { system } from 'project:utils/tokens.js'
 import '../shared.css'
-import { RuxDesignTokenPreview } from '@astrouxds/documentation-components' 
+import { RuxDesignTokenPreview } from '@astrouxds/documentation-components'
 
 const title = 'System Tokens'
 const description = 'Tokens representing Astro semantic design decisions.'
@@ -14,7 +14,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			{
 				system('light', 'color', 'background').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -32,7 +32,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			{
 				system('light', 'color', 'text').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -50,7 +50,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			{
 				system('light', 'color', 'border').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -68,7 +68,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			{
 				system('light', 'color', 'status').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -86,7 +86,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			{
 				system('light', 'color', 'classification').map((token) => (
 					<RuxDesignTokenPreview
-    client:visible
+    client:load
 						name={token.name}
 						value={token.value}
 						alias={token.referenceToken}
@@ -102,7 +102,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 		{
 			system('light', 'color', 'data-visualization').map((token) => (
 				<RuxDesignTokenPreview
-    client:visible
+    client:load
 					name={token.name}
 					value={token.value}
 					alias={token.referenceToken}


### PR DESCRIPTION
This PR fixes an issue with the way AstroJS was rendering our `rux-design-token-preview` component that was making it so the clipboard API was not copying to clipboard. The fix was to change client:visible to client:load on `rux-design-token-preview`. This allowed AstroJS to properly hydrate the component so the clipboard API would work.