### PR TITLE
chore(reference-token-docs): updating font weight docs to match design tokens package change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@astropub/webcomponent-polyfills": "file:.vscode/astropub-webcomponent-polyfills-0.1.1.tgz",
 				"@astrouxds/astrouxds-figma-assets": "^0.0.5",
 				"@astrouxds/documentation-components": "^0.0.16",
-				"@astrouxds/tokens": "^1.12.0",
+				"@astrouxds/tokens": "^1.13.0",
 				"@csstools/custom-units": "0.1.1",
 				"@typescript-eslint/eslint-plugin": "6.0.0",
 				"@typescript-eslint/parser": "6.0.0",
@@ -388,9 +388,9 @@
 			}
 		},
 		"node_modules/@astrouxds/tokens": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.12.0.tgz",
-			"integrity": "sha512-YRzKZkM8SfMW5p7qJRTMca7Kd6f06k4RTh8bB8Rf8aWlytCsh6iurC9F8cg05NpskvubZPMib26SGjtoX07S+Q==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.13.0.tgz",
+			"integrity": "sha512-yBP/sMuswdrwVRHnzkNaOfBMESEHlcfqFA6FPq6LxatTXZHtB9w/lRfsG/Uptu37MhfjnDSXsFLOWTY5QpTaPw==",
 			"dev": true
 		},
 		"node_modules/@babel/code-frame": {
@@ -13330,9 +13330,9 @@
 			}
 		},
 		"@astrouxds/tokens": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.12.0.tgz",
-			"integrity": "sha512-YRzKZkM8SfMW5p7qJRTMca7Kd6f06k4RTh8bB8Rf8aWlytCsh6iurC9F8cg05NpskvubZPMib26SGjtoX07S+Q==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.13.0.tgz",
+			"integrity": "sha512-yBP/sMuswdrwVRHnzkNaOfBMESEHlcfqFA6FPq6LxatTXZHtB9w/lRfsG/Uptu37MhfjnDSXsFLOWTY5QpTaPw==",
 			"dev": true
 		},
 		"@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@astropub/webcomponent-polyfills": "file:.vscode/astropub-webcomponent-polyfills-0.1.1.tgz",
 		"@astrouxds/astrouxds-figma-assets": "^0.0.5",
 		"@astrouxds/documentation-components": "^0.0.16",
-		"@astrouxds/tokens": "^1.12.0",
+		"@astrouxds/tokens": "^1.13.0",
 		"@csstools/custom-units": "0.1.1",
 		"@typescript-eslint/eslint-plugin": "6.0.0",
 		"@typescript-eslint/parser": "6.0.0",

--- a/src/pages/design-tokens/reference/index.astro
+++ b/src/pages/design-tokens/reference/index.astro
@@ -52,18 +52,46 @@ client:load
 	<h2 id="font-weight">
 		Font Weight
 	</h2>
-	{
-		reference('dark', 'fontWeights').map((token) => (
-			<RuxDesignTokenPreview
+	<div class="note">
+		<p>
+			The font weight tokens have dropped the 's' on the word weights.
+			<br>The old tokens using '--font-weights-light, --font-weights-regular, etc' instead of '--font-weight' are still compatible.
+		</p>
+	</div>
+	<!-- Font weights need to found by name since the fontWeights to fontWeight change.
+	Mapping through fontWeight from the tokens JSON will now give you more than just the font-weight tokens. -->
+	<RuxDesignTokenPreview
     client:load
-				name={token.name}
-				value={token.value}
-				alias={token.referenceToken}
-				description={token.description}
-				type="font-weight"
-			/>
-		))
-	}
+		name={findByName('font-weight-light')?.name}
+		value={findByName('font-weight-light')?.value}
+		alias={findByName('font-weight-light')?.referenceToken}
+		description={findByName('font-weight-light')?.description}
+		type="font-family"
+	/>
+	<RuxDesignTokenPreview
+    client:load
+		name={findByName('font-weight-regular')?.name}
+		value={findByName('font-weight-regular')?.value}
+		alias={findByName('font-weight-regular')?.referenceToken}
+		description={findByName('font-weight-regular')?.description}
+		type="font-family"
+	/>
+	<RuxDesignTokenPreview
+    client:load
+		name={findByName('font-weight-medium')?.name}
+		value={findByName('font-weight-medium')?.value}
+		alias={findByName('font-weight-medium')?.referenceToken}
+		description={findByName('font-weight-medium')?.description}
+		type="font-family"
+	/>
+	<RuxDesignTokenPreview
+    client:load
+		name={findByName('font-weight-bold')?.name}
+		value={findByName('font-weight-bold')?.value}
+		alias={findByName('font-weight-bold')?.referenceToken}
+		description={findByName('font-weight-bold')?.description}
+		type="font-family"
+	/>
 
 	<hr />
 

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -17,7 +17,6 @@ export const reference = (theme: string, category: string) => {
 			return parseFloat(String(a.value)) - parseFloat(String(b.value))
 		})
 	}
-
 	return themeTokens
 }
 


### PR DESCRIPTION
This PR is an update to the reference tokens documentation for font weight. A change was made in our Astro design tokens package to support both `--font-weights-light, --font-weights-regular` etc, as well as `--font-weight-light, --font-weight-regular`. Dropping the 's' on the token will make it match up to the Figma design tokens and makes everything more clear for the designers and makes the devs more aligned. 

The tokens with the additional 's' will still work, which is why a note was added, but we are recommending that devs now use the token without the 's'.

Grabbing the tokens in the actual file also had to be tweaked to get the token specifically by name instead of in a group to be mapped through as fontWeight instead of fontWeights as a category is broader and grabs more things than just the core font tokens.