### PR TITLE
feat(feedback widget / source code request): use description in source code request and email required in feedback widget

### DIFF
--- a/src/components/feedback-widgets/feedback-widget-custom-element.shadow.css
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.shadow.css
@@ -138,6 +138,9 @@
 			gap: 2--step;
 			justify-content: center;
 
+			/* Layout */
+			margin-block-start: 3--step;
+
 			& input[type="checkbox"] {
 				/* Layout */
 				margin: 0;
@@ -170,6 +173,11 @@
 					background-position: center;
 					background-repeat: no-repeat;
 				}
+			}
+
+			& label {
+				/* Text */
+				line-height: 5--step;
 			}
 		}
 
@@ -204,6 +212,9 @@
 
 			/* Layout */
 			margin-block-start: 6--step;
+
+			/* Text */
+			vertical-align: top;
 		}
 
 		& input {

--- a/src/components/feedback-widgets/feedback-widget-custom-element.shadow.css
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.shadow.css
@@ -130,11 +130,54 @@
 			}
 		}
 
+		& .widget_user-receive-response-wrapper {
+			display: flex;
+
+			/* Layout */
+			align-items: center;
+			gap: 2--step;
+			justify-content: center;
+
+			& input[type="checkbox"] {
+				/* Layout */
+				margin: 0;
+
+				/* Appearance */
+				appearance: none;
+
+				/* Appearance */
+				background-color: var(--PrimaryColor);
+
+				&::after {
+					display: flex;
+
+					/* Layout */
+					block-size: 5--step;
+					inline-size: 5--step;
+
+					/* Appearance */
+					background-color: var(--PrimaryColor);
+					border-radius: var(--EdgeRadius);
+					box-shadow: var(--DarkBlue400Color) 0 0 0 1px inset;
+
+					/* Generated */
+					content: "";
+				}
+
+				&:checked::after {
+					/* Appearance */
+					background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMyIgaGVpZ2h0PSIxMiIgdmlld0JveD0iMCAwIDEzIDEyIiBmaWxsPSJub25lIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik01LjQxNDk1IDExLjI3MTJMNi41NjIxIDkuNjMyOTFMNi41NjIwNiA5LjYzMjg5TDEyLjI5NzggMS40NDEzOEwxMC42NTk1IDAuMjk0MjI5TDQuOTIzNzYgOC40ODU3M0wxLjY0NzE5IDYuMTkxNDVMMC41MDAwMzUgNy44Mjk3NkwzLjc3NjYxIDEwLjEyNEwzLjc3NjYgMTAuMTI0MUw1LjQxNDkgMTEuMjcxMkw1LjQxNDkxIDExLjI3MTJMNS40MTQ5NSAxMS4yNzEyWiIgZmlsbD0iIzAwNUE4RiIvPgo8L3N2Zz4=");
+					background-position: center;
+					background-repeat: no-repeat;
+				}
+			}
+		}
+
 		& .current-url {
 			display: none;
 		}
 
-		& textarea, input {
+		& textarea, input:not([type="checkbox"]) {
 			/* Layout */
 			box-sizing: border-box;
 

--- a/src/components/feedback-widgets/feedback-widget-custom-element.shadow.html
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.shadow.html
@@ -15,7 +15,7 @@
 			</button>
 		</div>
 	</div>
-	<form method="post" id="feedback-form" action="https://astrouxds-ap-feat-ap-18-vt7pmj.herokuapp.com/api/v1/feedback">
+	<form method="post" id="feedback-form" action="https://astrouxds-api-196cde1c48d0.herokuapp.com/api/v1/feedback">
 		<input type="radio" id="radio_thumbs-up" name="user-feedback-radio" value="thumbs-up" required>
 		<input type="radio" id="radio_thumbs-down" name="user-feedback-radio" value="thumbs-down" required>
 		<textarea id="user-input" name="user-feedback" placeholder="Tell us why you gave that rating (optional)"></textarea>
@@ -23,7 +23,7 @@
 			<input type="checkbox" id="widget_receive-response" name="user-receive-response" value="">
 			<label for="user-receive-response">I'd like a response</label>
 		</span>
-		<input id="user-email" name="user-feedback" type="email" placeholder="Email Address (optional)" />
+		<input id="user-email" name="user-email" type="email" placeholder="Email Address (optional)" />
 		<div class="widget_button-group">
 			<button type="reset" class="widget_secondary-button"><slot name="secondaryButtonName">Clear</slot></button>
 			<button class="widget_primary-button" type="submit" value="Submit" disabled>Submit</button>

--- a/src/components/feedback-widgets/feedback-widget-custom-element.shadow.html
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.shadow.html
@@ -15,10 +15,9 @@
 			</button>
 		</div>
 	</div>
-	<form method="post" id="feedback-form" action="https://astrouxds-api-196cde1c48d0.herokuapp.com/api/v1/feedback">
+	<form method="post" id="feedback-form" action="https://astrouxds-ap-feat-ap-18-vt7pmj.herokuapp.com/api/v1/feedback">
 		<input type="radio" id="radio_thumbs-up" name="user-feedback-radio" value="thumbs-up" required>
 		<input type="radio" id="radio_thumbs-down" name="user-feedback-radio" value="thumbs-down" required>
-		<input type="text" id="current-url" class="current-url" name="pageURL" value="">
 		<textarea id="user-input" name="user-feedback" placeholder="Tell us why you gave that rating (optional)"></textarea>
 		<span class="widget_user-receive-response-wrapper">
 			<input type="checkbox" id="widget_receive-response" name="user-receive-response" value="">

--- a/src/components/feedback-widgets/feedback-widget-custom-element.shadow.html
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.shadow.html
@@ -16,10 +16,14 @@
 		</div>
 	</div>
 	<form method="post" id="feedback-form" action="https://astrouxds-api-196cde1c48d0.herokuapp.com/api/v1/feedback">
-		<input type="radio" id="radio_thumbs-up" name="user-feedback-radio" value="thumbs-up">
-		<input type="radio" id="radio_thumbs-down" name="user-feedback-radio" value="thumbs-down">
+		<input type="radio" id="radio_thumbs-up" name="user-feedback-radio" value="thumbs-up" required>
+		<input type="radio" id="radio_thumbs-down" name="user-feedback-radio" value="thumbs-down" required>
 		<input type="text" id="current-url" class="current-url" name="pageURL" value="">
 		<textarea id="user-input" name="user-feedback" placeholder="Tell us why you gave that rating (optional)"></textarea>
+		<span class="widget_user-receive-response-wrapper">
+			<input type="checkbox" id="widget_receive-response" name="user-receive-response" value="">
+			<label for="user-receive-response">I'd like a response</label>
+		</span>
 		<input id="user-email" name="user-feedback" type="email" placeholder="Email Address (optional)" />
 		<div class="widget_button-group">
 			<button type="reset" class="widget_secondary-button"><slot name="secondaryButtonName">Clear</slot></button>

--- a/src/components/feedback-widgets/feedback-widget-custom-element.ts
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.ts
@@ -14,28 +14,54 @@ class FeedbackWidget extends HTMLElement {
 
 		// grabs current url from passed in attribute and sets it in the form
 		const currentURL: string = this.getAttribute('current-url')!
-		const currentURLInput = root?.getElementById('current-url') as HTMLInputElement
+		const currentURLInput = root?.getElementById(
+			'current-url'
+		) as HTMLInputElement
 		currentURLInput.value = currentURL
 		currentURLInput.setAttribute('value', currentURL)
 
 		// document elements
-		const widgetWrapper: HTMLElement | null = document.querySelector('.widget_wrapper')
-		const widgetInteriorWrapper: HTMLElement | null = document.querySelector('.widget_interior-wrapper')
-		const topTab: HTMLElement | null = document.querySelector('.widget_top-tab')
-		const widgetContent: HTMLElement | null = document.querySelector('.widget_content-wrapper')
+		const widgetWrapper: HTMLElement | null =
+			document.querySelector('.widget_wrapper')
+		const widgetInteriorWrapper: HTMLElement | null = document.querySelector(
+			'.widget_interior-wrapper'
+		)
+		const topTab: HTMLElement | null =
+			document.querySelector('.widget_top-tab')
+		const widgetContent: HTMLElement | null = document.querySelector(
+			'.widget_content-wrapper'
+		)
 		const pageFooter: HTMLElement = document.querySelector('.p-footer')!
 
 		// shadow elements
 		const form: HTMLFormElement = root.querySelector('form#feedback-form')!
-		const clearButton: HTMLButtonElement = root.querySelector('.widget_secondary-button')!
-		const rateButtons: NodeListOf<HTMLButtonElement> = root.querySelectorAll('.widget_rate-group button')!
-		const submitButton: HTMLButtonElement = root.querySelector('.widget_primary-button')!
-		const emailInput: HTMLInputElement = root.querySelector('input[type="email"]#user-email')!
-		const textarea: HTMLTextAreaElement = root.querySelector('textarea#user-input')!
-		const hiddenThumbsUpRadio: HTMLInputElement = root.querySelector('#radio_thumbs-up')!
-		const hiddenThumbsDownRadio: HTMLInputElement = root.querySelector('#radio_thumbs-down')!
-		const urlInput: HTMLInputElement = root.querySelector('input[type="text"]#current-url')!
-		const widgetSuccess: HTMLDivElement = root.querySelector('.widget_success')!
+		const clearButton: HTMLButtonElement = root.querySelector(
+			'.widget_secondary-button'
+		)!
+		const rateButtons: NodeListOf<HTMLButtonElement> = root.querySelectorAll(
+			'.widget_rate-group button'
+		)!
+		const submitButton: HTMLButtonElement = root.querySelector(
+			'.widget_primary-button'
+		)!
+		const receiveResponseCheckbox: HTMLInputElement = root.querySelector(
+			'input[type="checkbox"]#widget_receive-response'
+		)!
+		const emailInput: HTMLInputElement = root.querySelector(
+			'input[type="email"]#user-email'
+		)!
+		const textarea: HTMLTextAreaElement = root.querySelector(
+			'textarea#user-input'
+		)!
+		const hiddenThumbsUpRadio: HTMLInputElement =
+			root.querySelector('#radio_thumbs-up')!
+		const hiddenThumbsDownRadio: HTMLInputElement =
+			root.querySelector('#radio_thumbs-down')!
+		const urlInput: HTMLInputElement = root.querySelector(
+			'input[type="text"]#current-url'
+		)!
+		const widgetSuccess: HTMLDivElement =
+			root.querySelector('.widget_success')!
 		const widgetFail: HTMLDivElement = root.querySelector('.widget_fail')!
 
 		// booleans
@@ -67,23 +93,45 @@ class FeedbackWidget extends HTMLElement {
 
 			// map selected button state to checked state of hidden radios
 			if (button.id === 'button_thumbs-up') {
-				button.classList.contains('selected') ? hiddenThumbsUpRadio.setAttribute('checked', '') : hiddenThumbsUpRadio.removeAttribute('checked')
+				button.classList.contains('selected')
+					? hiddenThumbsUpRadio.setAttribute('checked', '')
+					: hiddenThumbsUpRadio.removeAttribute('checked')
 			}
 
 			if (button.id === 'button_thumbs-down') {
-				button.classList.contains('selected') ? hiddenThumbsDownRadio.setAttribute('checked', '') : hiddenThumbsDownRadio.removeAttribute('checked')
+				button.classList.contains('selected')
+					? hiddenThumbsDownRadio.setAttribute('checked', '')
+					: hiddenThumbsDownRadio.removeAttribute('checked')
 			}
 		}
 
+		const handleReceiveResponse = () => {
+			receiveResponseCheckbox.addEventListener('change', () => {
+				if (receiveResponseCheckbox.checked) {
+					emailInput.setAttribute('required', '')
+					emailInput.placeholder = 'Email Address (required)'
+				} else {
+					emailInput.placeholder = 'Email Address (optional)'
+					emailInput.removeAttribute('required')
+				}
+
+				handleSubmitButton()
+			})
+		}
+
 		const handleSubmitButton = () => {
-			// check booleans and enable/disable form submit button
-			if (!emailPopulated && !textareaPopulated && !rateButtonSelected) {
+			// no rating button selected, early return
+			if (!rateButtonSelected) {
 				submitButton.disabled = true
-			} else if (emailPopulated && !textareaPopulated && !rateButtonSelected) {
-				submitButton.disabled = true
-			} else {
-				submitButton.disabled = false
+				return
 			}
+
+			// receive response checked and email not populated, return
+			if (!emailPopulated && receiveResponseCheckbox.checked) {
+				submitButton.disabled = true
+				return
+			}
+			submitButton.disabled = false
 		}
 
 		const watchFooterScroll = () => {
@@ -91,7 +139,9 @@ class FeedbackWidget extends HTMLElement {
 			let viewportHeight: number = visualViewport.height
 			let difference: number = (footerBottom - viewportHeight) * -1
 
-			if (widgetWrapper !== null) widgetWrapper.style.insetBlockEnd = `${difference}px`
+			if (widgetWrapper !== null) {
+				widgetWrapper.style.insetBlockEnd = `${difference}px`
+			}
 		}
 
 		const watchForFooter = () => {
@@ -106,7 +156,9 @@ class FeedbackWidget extends HTMLElement {
 						document.addEventListener('scroll', watchFooterScroll)
 					} else {
 						document.removeEventListener('scroll', watchFooterScroll)
-						if (widgetWrapper !== null) widgetWrapper.style.insetBlockEnd = `0px`
+						if (widgetWrapper !== null) {
+							widgetWrapper.style.insetBlockEnd = `0px`
+						}
 					}
 				})
 			}
@@ -136,11 +188,17 @@ class FeedbackWidget extends HTMLElement {
 			toggleAttributes(true)
 
 			// get tab size to account for widget positioning on open/close
-			const tabSize = topTab?.getBoundingClientRect()[visualViewport.width < 1024 ? 'width' : 'height']
+			const tabSize =
+				topTab?.getBoundingClientRect()[
+					visualViewport.width < 1024 ? 'width' : 'height'
+				]
 
 			// set min max values for keyframe animation
 			let keyframeInteriorMin: Record<string, string> = {
-				translate: visualViewport.width < 1024 ? `calc(100% - ${tabSize}px) 0%` : `0% calc(100% - ${tabSize}px)`,
+				translate:
+					visualViewport.width < 1024
+						? `calc(100% - ${tabSize}px) 0%`
+						: `0% calc(100% - ${tabSize}px)`,
 			}
 			let keyframeInteriorMax: Record<string, string> = {
 				translate: `0% 0%`,
@@ -165,27 +223,25 @@ class FeedbackWidget extends HTMLElement {
 			}
 
 			const keyframes = toggle ? [ min, max ] : [ max, min ]
-			const keyframesInterior = toggle ? [ keyframeInteriorMin, keyframeInteriorMax ] : [ keyframeInteriorMax, keyframeInteriorMin ]
+			const keyframesInterior = toggle
+				? [ keyframeInteriorMin, keyframeInteriorMax ]
+				: [ keyframeInteriorMax, keyframeInteriorMin ]
 
 			// animate interior wrapper
-			widgetInteriorWrapper?.animate(
-				keyframesInterior,
-				{
-					duration: 200,
-					iterations: 1,
-				}
-			)
+			widgetInteriorWrapper?.animate(keyframesInterior, {
+				duration: 200,
+				iterations: 1,
+			})
 
 			// animate content wrapper
-			widgetContent?.animate(
-				keyframes,
-				{
+			widgetContent
+				?.animate(keyframes, {
 					duration: 200,
 					iterations: 1,
-				}
-			).finished.then(() => {
-				toggleAttributes(toggle)
-			})
+				})
+				.finished.then(() => {
+					toggleAttributes(toggle)
+				})
 		}
 
 		const handleRateButtonSelected = (button: HTMLButtonElement) => {
@@ -233,7 +289,8 @@ class FeedbackWidget extends HTMLElement {
 
 		const handleFormSubmit = (event: Event) => {
 			const antenna: SVGElement = widgetSuccess.querySelector('svg')!
-			const animatingElement: NodeListOf<HTMLSpanElement> = widgetSuccess.querySelectorAll('.widget_success-orange-circle span')!
+			const animatingElement: NodeListOf<HTMLSpanElement> =
+				widgetSuccess.querySelectorAll('.widget_success-orange-circle span')!
 
 			if (formSubmittable) {
 				// put receiving animation in place, dots animating into antenna
@@ -241,11 +298,11 @@ class FeedbackWidget extends HTMLElement {
 
 				const target = event.target as HTMLFormElement
 				let data = {
-					'feedback': textarea.value,
-					'thumbUp': hiddenThumbsUpRadio.checked,
-					'thumbDown': hiddenThumbsDownRadio.checked,
-					'email': emailInput.value,
-					'pageURL': urlInput.value,
+					feedback: textarea.value,
+					thumbUp: hiddenThumbsUpRadio.checked,
+					thumbDown: hiddenThumbsDownRadio.checked,
+					email: emailInput.value,
+					pageURL: urlInput.value,
 				}
 				const action = target.action
 				fetch(action, {
@@ -253,30 +310,31 @@ class FeedbackWidget extends HTMLElement {
 					method: 'POST',
 					body: JSON.stringify(data),
 				})
-				.then(() => {
-					// on success, make antenna success color, stop receiving animation after brief timeout.
-					setTimeout(() => {
-						antenna.classList.add('success')
-						for (const span of animatingElement) {
-							span.style.animationIterationCount = '1'
-						}
-					}, 900)
+					.then(() => {
+						// on success, make antenna success color, stop receiving animation after brief timeout.
+						setTimeout(() => {
+							antenna.classList.add('success')
+							for (const span of animatingElement) {
+								span.style.animationIterationCount = '1'
+							}
+						}, 900)
 
-					// after timeout, remove all success panels and close widget.
-					setTimeout(() => {
-						widgetSuccess.classList.remove('-active')
-						antenna.classList.remove('selected')
-						handleFormReset()
-						showHideWidget()
-					}, 2500)
-				}).catch(() => {
-					// on failure display failure panel, remove all panels.
-					widgetFail.classList.add('-active')
-					setTimeout(() => {
-						widgetSuccess.classList.remove('-active')
-						widgetFail.classList.remove('-active')
-					}, 2500)
-				})
+						// after timeout, remove all success panels and close widget.
+						setTimeout(() => {
+							widgetSuccess.classList.remove('-active')
+							antenna.classList.remove('selected')
+							handleFormReset()
+							showHideWidget()
+						}, 2500)
+					})
+					.catch(() => {
+						// on failure display failure panel, remove all panels.
+						widgetFail.classList.add('-active')
+						setTimeout(() => {
+							widgetSuccess.classList.remove('-active')
+							widgetFail.classList.remove('-active')
+						}, 2500)
+					})
 			}
 		}
 
@@ -295,11 +353,10 @@ class FeedbackWidget extends HTMLElement {
 			})
 		}
 
-
 		const handleTextareaListener = () => {
 			textarea.addEventListener('input', (event) => {
 				const target = event.currentTarget as HTMLInputElement
-				target.value ? textareaPopulated = true : textareaPopulated = false
+				target.value ? (textareaPopulated = true) : (textareaPopulated = false)
 
 				handleSubmitButton()
 				// set form boolean to true
@@ -310,7 +367,7 @@ class FeedbackWidget extends HTMLElement {
 		const handleEmailListener = () => {
 			emailInput.addEventListener('input', (event) => {
 				const target = event.currentTarget as HTMLInputElement
-				target.value ? emailPopulated = true : emailPopulated = false
+				target.value ? (emailPopulated = true) : (emailPopulated = false)
 
 				handleSubmitButton()
 			})
@@ -338,6 +395,7 @@ class FeedbackWidget extends HTMLElement {
 		handleClearButtonListener()
 		handleRateButtonListener()
 		handleTextareaListener()
+		handleReceiveResponse()
 		handleEmailListener()
 		handleFormListener()
 		watchForFooter()

--- a/src/components/feedback-widgets/feedback-widget-custom-element.ts
+++ b/src/components/feedback-widgets/feedback-widget-custom-element.ts
@@ -14,11 +14,6 @@ class FeedbackWidget extends HTMLElement {
 
 		// grabs current url from passed in attribute and sets it in the form
 		const currentURL: string = this.getAttribute('current-url')!
-		const currentURLInput = root?.getElementById(
-			'current-url'
-		) as HTMLInputElement
-		currentURLInput.value = currentURL
-		currentURLInput.setAttribute('value', currentURL)
 
 		// document elements
 		const widgetWrapper: HTMLElement | null =
@@ -57,9 +52,6 @@ class FeedbackWidget extends HTMLElement {
 			root.querySelector('#radio_thumbs-up')!
 		const hiddenThumbsDownRadio: HTMLInputElement =
 			root.querySelector('#radio_thumbs-down')!
-		const urlInput: HTMLInputElement = root.querySelector(
-			'input[type="text"]#current-url'
-		)!
 		const widgetSuccess: HTMLDivElement =
 			root.querySelector('.widget_success')!
 		const widgetFail: HTMLDivElement = root.querySelector('.widget_fail')!
@@ -71,6 +63,15 @@ class FeedbackWidget extends HTMLElement {
 
 		// intersection observer
 		let observer: IntersectionObserver | undefined
+
+		type FeedbackData = {
+			feedback: string;
+			thumbUp: boolean;
+			thumbDown: boolean;
+			receiveResponse: boolean;
+			email: string;
+			pageURL: string;
+		};
 
 		const handleRateButtonsRemoveSelected = () => {
 			// deselect UI buttons
@@ -281,13 +282,13 @@ class FeedbackWidget extends HTMLElement {
 			widgetSuccess.classList.add('-active')
 
 			const target = event.target as HTMLFormElement
-			let data = {
+			let data: FeedbackData = {
 				feedback: textarea.value,
 				thumbUp: hiddenThumbsUpRadio.checked,
 				thumbDown: hiddenThumbsDownRadio.checked,
 				receiveResponse: receiveResponseCheckbox.checked,
 				email: emailInput.value,
-				pageURL: urlInput.value,
+				pageURL: currentURL,
 			}
 			const action = target.action
 			fetch(action, {
@@ -297,20 +298,10 @@ class FeedbackWidget extends HTMLElement {
 			})
 				.then(() => {
 					// on success, make antenna success color, stop receiving animation after brief timeout.
-					setTimeout(() => {
-						antenna.classList.add('success')
-						for (const span of animatingElement) {
-							span.style.animationIterationCount = '1'
-						}
-					}, 900)
-
-					// after timeout, remove all success panels and close widget.
-					setTimeout(() => {
-						widgetSuccess.classList.remove('-active')
-						antenna.classList.remove('selected')
-						handleFormReset()
-						showHideWidget()
-					}, 2500)
+					antenna.classList.add('success')
+					for (const span of animatingElement) {
+						span.style.animationIterationCount = '1'
+					}
 				})
 				.catch(() => {
 					// on failure display failure panel, remove all panels.
@@ -318,7 +309,17 @@ class FeedbackWidget extends HTMLElement {
 					setTimeout(() => {
 						widgetSuccess.classList.remove('-active')
 						widgetFail.classList.remove('-active')
-					}, 2500)
+					}, 1200)
+				})
+				.finally(() => {
+					// small pause to allow animation to complete
+					// 1200ms matches animation in css file
+					setTimeout(() => {
+						widgetSuccess.classList.remove('-active')
+						antenna.classList.remove('selected')
+						handleFormReset()
+						showHideWidget()
+					}, 1200)
 				})
 		}
 

--- a/src/components/source-code-access/source-code-access.astro
+++ b/src/components/source-code-access/source-code-access.astro
@@ -43,7 +43,6 @@ const { data } = sourceCodeAccess
 				</fieldset>
 
 				<fieldset>
-					<legend>{data.useDescriptionLabel.data}</legend>
 					<div class="p-source-code-use-description">
 						<For of={data.useDescription.data}>{item => (
 								<textarea class="p-source-code-use-description" id={item.placeholder.data} name={item.name.data} placeholder={item.placeholder.data} rows="10" />

--- a/src/components/source-code-access/source-code-access.astro
+++ b/src/components/source-code-access/source-code-access.astro
@@ -7,77 +7,152 @@ import { For } from '@astropub/flow'
 
 const { data } = sourceCodeAccess
 ---
+
 <span class="p-source-code">
 	<dialog class="p-source-code-dialog">
 		<h3 class="p-source-code-heading">{data.heading.data}</h3>
 		<p class="p-source-code-content">{data.summary.data}</p>
-		<form class="p-source-code-form" name="code-access-request" id="code-access-request">
+		<form
+			class="p-source-code-form"
+			name="code-access-request"
+			id="code-access-request"
+		>
 			<div class="p-source-code-inputs">
-				<For of={data.content.data}>{item => (
-					<Control type={item.type.data} required={item.required.data} placeholder={item.placeholder.data} autocomplete={item.autocomplete.data} name={item.name.data}>{item.label.data}</Control>
-				)}</For>
+				<For of={data.content.data}>
+					{
+						(item) => (
+							<Control
+								type={item.type.data}
+								required={item.required.data}
+								placeholder={item.placeholder.data}
+								autocomplete={item.autocomplete.data}
+								name={item.name.data}
+							>
+								{item.label.data}
+							</Control>
+						)
+					}
+				</For>
 
 				<fieldset>
 					<legend>{data.useLabel.data}</legend>
 					<div class="p-source-code-use">
-						<For of={data.use.data}>{item => (
-							<span>
-								<input id={item.placeholder.data} type={item.type.data as 'radio'} name={item.name.data} value={item.placeholder.data} checked={item.checked.data} />
-								<label for={item.placeholder.data}>{item.label.data}</label>
-							</span>
-						)}</For>
+						<For of={data.use.data}>
+							{
+								(item) => (
+									<span>
+										<input
+											id={item.placeholder.data}
+											type={item.type.data as 'radio'}
+											name={item.name.data}
+											value={item.placeholder.data}
+											checked={item.checked.data}
+										/>
+										<label for={item.placeholder.data}>{item.label.data}</label>
+									</span>
+								)
+							}
+						</For>
 					</div>
 				</fieldset>
 
 				<fieldset>
 					<legend>{data.accessLabel.data}</legend>
 					<div class="p-source-code-apps">
-						<For of={data.apps.data}>{item => (
-							<span>
-								<input class="p-source-code-app-checkbox" id={item.placeholder.data} type={item.type.data as 'checkbox'} name={item.name.data} value={item.placeholder.data} />
-								<label for={item.placeholder.data}>{item.label.data}</label>
-							</span>
-						)}</For>
+						<For of={data.apps.data}>
+							{
+								(item) => (
+									<span>
+										<input
+											class="p-source-code-app-checkbox"
+											id={item.placeholder.data}
+											type={item.type.data as 'checkbox'}
+											name={item.name.data}
+											value={item.placeholder.data}
+										/>
+										<label for={item.placeholder.data}>{item.label.data}</label>
+									</span>
+								)
+							}
+						</For>
 					</div>
-					<small class="p-source-code-apps-error" />
+					<small class="p-source-code-apps-error"></small>
 				</fieldset>
 
-				<fieldset>
-					<div class="p-source-code-use-description">
-						<For of={data.useDescription.data}>{item => (
-								<textarea class="p-source-code-use-description" id={item.placeholder.data} name={item.name.data} placeholder={item.placeholder.data} rows="10" />
-								<label for={item.name.data}>{item.label.data}</label>
-						)}</For>
-					</div>
-				</fieldset>
+				<div class="p-source-code-use-description">
+					<For of={data.useDescription.data}>
+						{
+							(item) => (
+								<>
+									<textarea
+										id={item.placeholder.data}
+										name={item.name.data}
+										placeholder={item.placeholder.data}
+										rows="10"
+									/>
+									<label for={item.name.data}>{item.label.data}</label>
+								</>
+							)
+						}
+					</For>
+				</div>
 
 				<fieldset class="p-source-code-subscribe">
 					<input id="subscribe" type="checkbox" name="subscribe" checked />
-					<label for="subscribe">Subscribe to Astro UXDS News and Updates?</label>
+					<label for="subscribe"
+						>Subscribe to Astro UXDS News and Updates?</label
+					>
 				</fieldset>
 
-				<small class="p-source-code-error" />
+				<small class="p-source-code-error"></small>
 			</div>
 
 			<footer class="p-source-code-footer">
-				<button type="reset" class="p-source-code-button p-source-code-dialog-close secondary">Cancel</button>
-				<button type="submit" class="p-source-code-button p-source-code-dialog-submit">
+				<button
+					type="reset"
+					class="p-source-code-button p-source-code-dialog-close secondary"
+					>Cancel</button
+				>
+				<button
+					type="submit"
+					class="p-source-code-button p-source-code-dialog-submit"
+				>
 					<div class="loading-container">Submit</div>
 				</button>
 			</footer>
 		</form>
 	</dialog>
 
-	<div class="p-source-code-success-popover" popover="manual" id="success-popover">
+	<div
+		class="p-source-code-success-popover"
+		popover="manual"
+		id="success-popover"
+	>
 		<div class="p-source-code-success-content">
-			<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-				<path d="m9 16.2-3.5-3.5a.984.984 0 0 0-1.4 0 .984.984 0 0 0 0 1.4l4.19 4.19c.39.39 1.02.39 1.41 0L20.3 7.7a.984.984 0 0 0 0-1.4.984.984 0 0 0-1.4 0L9 16.2Z"></path>
+			<svg
+				width="24"
+				height="24"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+			>
+				<path
+					d="m9 16.2-3.5-3.5a.984.984 0 0 0-1.4 0 .984.984 0 0 0 0 1.4l4.19 4.19c.39.39 1.02.39 1.41 0L20.3 7.7a.984.984 0 0 0 0-1.4.984.984 0 0 0-1.4 0L9 16.2Z"
+				></path>
 			</svg>
-			<span class="p-source-code-success-message">Successfully submitted request for source code</span>
+			<span class="p-source-code-success-message"
+				>Successfully submitted request for source code</span
+			>
 		</div>
 		<button class="p-source-code-success-close" popovertarget="success-popover">
-			<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-				<path d="M18.3 5.71a.996.996 0 0 0-1.41 0L12 10.59 7.11 5.7A.996.996 0 1 0 5.7 7.11L10.59 12 5.7 16.89a.996.996 0 1 0 1.41 1.41L12 13.41l4.89 4.89a.996.996 0 1 0 1.41-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4Z"></path>
+			<svg
+				width="24"
+				height="24"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+			>
+				<path
+					d="M18.3 5.71a.996.996 0 0 0-1.41 0L12 10.59 7.11 5.7A.996.996 0 1 0 5.7 7.11L10.59 12 5.7 16.89a.996.996 0 1 0 1.41 1.41L12 13.41l4.89 4.89a.996.996 0 1 0 1.41-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4Z"
+				></path>
 			</svg>
 		</button>
 	</div>

--- a/src/components/source-code-access/source-code-access.astro
+++ b/src/components/source-code-access/source-code-access.astro
@@ -43,13 +43,11 @@ const { data } = sourceCodeAccess
 				</fieldset>
 
 				<fieldset>
-					<legend>{data.useDescription.data}</legend>
+					<legend>{data.useDescriptionLabel.data}</legend>
 					<div class="p-source-code-use-description">
 						<For of={data.useDescription.data}>{item => (
-							<span>
-								<textarea class="p-source-code-app-checkbox" id={item.placeholder.data} name={item.name.data} value={item.placeholder.data} />
-								<label for={item.placeholder.data}>{item.label.data}</label>
-							</span>
+								<textarea class="p-source-code-use-description" id={item.placeholder.data} name={item.name.data} placeholder={item.placeholder.data} rows="10" />
+								<label for={item.name.data}>{item.label.data}</label>
 						)}</For>
 					</div>
 				</fieldset>

--- a/src/components/source-code-access/source-code-access.astro
+++ b/src/components/source-code-access/source-code-access.astro
@@ -42,6 +42,18 @@ const { data } = sourceCodeAccess
 					<small class="p-source-code-apps-error" />
 				</fieldset>
 
+				<fieldset>
+					<legend>{data.useDescription.data}</legend>
+					<div class="p-source-code-use-description">
+						<For of={data.useDescription.data}>{item => (
+							<span>
+								<textarea class="p-source-code-app-checkbox" id={item.placeholder.data} name={item.name.data} value={item.placeholder.data} />
+								<label for={item.placeholder.data}>{item.label.data}</label>
+							</span>
+						)}</For>
+					</div>
+				</fieldset>
+
 				<fieldset class="p-source-code-subscribe">
 					<input id="subscribe" type="checkbox" name="subscribe" checked />
 					<label for="subscribe">Subscribe to Astro UXDS News and Updates?</label>

--- a/src/components/source-code-access/source-code-access.css
+++ b/src/components/source-code-access/source-code-access.css
@@ -216,6 +216,39 @@
 	background-position: center;
 }
 
+.p-source-code-use-description {
+	display: flex;
+
+	/* Layout */
+	flex-direction: column-reverse;
+
+	& textarea {
+		/* Layout */
+		padding-block: 4--step;
+		padding-inline-start: 4--step;
+
+		/* Appearance */
+		background: var(--BaseColor);
+
+		/* Appearance */
+		border: none;
+		border-radius: var(--EdgeRadius);
+		box-shadow: var(--InteractiveMutedColor) 0 0 0 1px inset;
+		color: var(--PrimaryColor);
+
+		&:is(:hover, :focus-visible) {
+			/* Appearance */
+			box-shadow: var(--InteractiveHoverColor) 0 0 0 1px inset;
+		}
+
+		&::placeholder {
+			/* Text */
+			font-family: Helvetica, system-ui;
+			font-size: 1rem;
+		}
+	}
+}
+
 .p-source-code-button {
 	/* Layout */
 	padding-block: 2--step;

--- a/src/components/source-code-access/source-code-access.css
+++ b/src/components/source-code-access/source-code-access.css
@@ -68,7 +68,7 @@
 
 			/* Layout */
 			flex-flow: column;
-			gap: 8--step;
+			gap: 6--step;
 			padding-block: 4--step;
 			padding-inline: 4--step;
 
@@ -221,11 +221,17 @@
 
 	/* Layout */
 	flex-direction: column-reverse;
+	gap: 2--step;
+	inline-size: 100%;
 
 	& textarea {
 		/* Layout */
 		padding-block: 4--step;
 		padding-inline-start: 4--step;
+
+		/* Text */
+		font-family: Helvetica, system-ui;
+		font-size: 1rem;
 
 		/* Appearance */
 		background: var(--BaseColor);

--- a/src/components/source-code-access/source-code-access.ts
+++ b/src/components/source-code-access/source-code-access.ts
@@ -89,7 +89,7 @@ form.addEventListener('submit', async (e) => {
 	console.log('params: ', params)
 
 	try {
-		const url = 'https://astrouxds-ap-feat-ap-18-vt7pmj.herokuapp.com/api/v1/source-code'
+		const url = 'https://astrouxds-api-196cde1c48d0.herokuapp.com/api/v1/source-code'
 		const res = await fetch(url, { method: 'post', body: JSON.stringify(params) })
 		const status = res.status
 		const data = await res.json()

--- a/src/components/source-code-access/source-code-access.ts
+++ b/src/components/source-code-access/source-code-access.ts
@@ -67,6 +67,8 @@ form.addEventListener('submit', async (e) => {
 	const data = new FormData(form)
 	const params = new RequestParams()
 
+	console.log('data: ', data)
+
 	for (const entry of data) {
 		const key = entry[0] as keyof RequestParams
 		const value = entry[1] as string
@@ -84,8 +86,10 @@ form.addEventListener('submit', async (e) => {
 		return
 	}
 
+	console.log('params: ', params)
+
 	try {
-		const url = 'https://astrouxds-api-196cde1c48d0.herokuapp.com/api/v1/source-code'
+		const url = 'https://astrouxds-ap-feat-ap-18-vt7pmj.herokuapp.com/api/v1/source-code'
 		const res = await fetch(url, { method: 'post', body: JSON.stringify(params) })
 		const status = res.status
 		const data = await res.json()

--- a/src/components/source-code-access/source-code-access.ts
+++ b/src/components/source-code-access/source-code-access.ts
@@ -18,6 +18,7 @@ class RequestParams {
 	first: string = ''
 	last: string = ''
 	use: string = ''
+	useDescription: string = ''
 	subscribe: string = 'off'
 }
 
@@ -70,7 +71,7 @@ form.addEventListener('submit', async (e) => {
 		const key = entry[0] as keyof RequestParams
 		const value = entry[1] as string
 		if (key === 'apps') {
-			params.apps = [...params.apps, value]
+			params.apps = [ ...params.apps, value ]
 		} else {
 			params[key] = value
 		}

--- a/src/components/source-code-access/source-code-access.ts
+++ b/src/components/source-code-access/source-code-access.ts
@@ -67,8 +67,6 @@ form.addEventListener('submit', async (e) => {
 	const data = new FormData(form)
 	const params = new RequestParams()
 
-	console.log('data: ', data)
-
 	for (const entry of data) {
 		const key = entry[0] as keyof RequestParams
 		const value = entry[1] as string
@@ -85,8 +83,6 @@ form.addEventListener('submit', async (e) => {
 		resetLoading()
 		return
 	}
-
-	console.log('params: ', params)
 
 	try {
 		const url = 'https://astrouxds-api-196cde1c48d0.herokuapp.com/api/v1/source-code'

--- a/src/data/source-code-access.json
+++ b/src/data/source-code-access.json
@@ -266,6 +266,37 @@
 					}
 				}
 			]
+		},
+		"useDescription": {
+			"type": "objects",
+			"data": [
+				{
+					"type": {
+						"type": "text",
+						"data": "text"
+					},
+					"name": {
+						"type": "text",
+						"data": "description"
+					},
+					"label": {
+						"type": "text",
+						"data": "To help Astro better improve, please tell us a little bit about your project."
+					},
+					"autocomplete": {
+						"type": "text",
+						"data": "description"
+					},
+					"placeholder": {
+						"type": "text",
+						"data": "Tell us about your project to help us better support you."
+					},
+					"required": {
+						"type": "switch",
+						"data": false
+					}
+				}
+			]
 		}
 	}
 }

--- a/src/data/source-code-access.json
+++ b/src/data/source-code-access.json
@@ -277,15 +277,11 @@
 					},
 					"name": {
 						"type": "text",
-						"data": "description"
+						"data": "useDescription"
 					},
 					"label": {
 						"type": "text",
 						"data": "To help Astro better improve, please tell us a little bit about your project."
-					},
-					"autocomplete": {
-						"type": "text",
-						"data": "description"
 					},
 					"placeholder": {
 						"type": "text",

--- a/src/data/source-code-access.json
+++ b/src/data/source-code-access.json
@@ -18,10 +18,6 @@
 			"type": "text",
 			"data": "Which Astro App’s Source Code Would You Like Access to?"
 		},
-		"useDescriptionLabel": {
-			"type": "text",
-			"data": "To help Astro better improve, please tell us a little bit about your project."
-		},
 		"content": {
 			"type": "objects",
 			"data": [
@@ -285,7 +281,7 @@
 					},
 					"label": {
 						"type": "text",
-						"data": "Use Description"
+						"data": "To help Astro better improve, please tell us a little bit about your project."
 					},
 					"autocomplete": {
 						"type": "text",

--- a/src/data/source-code-access.json
+++ b/src/data/source-code-access.json
@@ -18,6 +18,10 @@
 			"type": "text",
 			"data": "Which Astro App’s Source Code Would You Like Access to?"
 		},
+		"useDescriptionLabel": {
+			"type": "text",
+			"data": "To help Astro better improve, please tell us a little bit about your project."
+		},
 		"content": {
 			"type": "objects",
 			"data": [
@@ -281,7 +285,7 @@
 					},
 					"label": {
 						"type": "text",
-						"data": "To help Astro better improve, please tell us a little bit about your project."
+						"data": "Use Description"
 					},
 					"autocomplete": {
 						"type": "text",


### PR DESCRIPTION
This PR includes two changes:

- An additional textarea in the source code request modal to include a description of the requester's use case. This gets mapped in the backend to our Google sheet and included in both the notification and confirmation emails.
- An additional checkbox in the feedback widget for the user to check if they would like a response. This makes the email field required. This is also mapped to our backend and to an additional column in our Google sheet, and in the emails that are auto-generated.
- Some additional cleanup and tuning of the feedback widget.