### PR TITLE
fix(design-tokens): adding missing system and component tokens

### DIFF
--- a/src/pages/design-tokens/component/index.astro
+++ b/src/pages/design-tokens/component/index.astro
@@ -276,6 +276,24 @@ const description = 'Component specific tokens to be used only when rebuilding c
 
 	<hr />
 
+	<h2 id="push-button">
+		Push Button
+	</h2>
+	{
+		component('dark', 'push-button').map((token) => (
+			<RuxDesignTokenPreview
+    client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type={lookupProperty(token.category, token.property)}
+			/>
+		))
+	}
+
+	<hr />
+
 
 	<h2 id="radio">
 		Radio
@@ -382,6 +400,24 @@ const description = 'Component specific tokens to be used only when rebuilding c
 	}
 
 	<hr />
+
+	<h2 id="tab">
+		Tab
+	</h2>
+	{
+		component('dark', 'tab').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type={lookupProperty(token.category, token.property)}
+			/>
+		))
+	}
+	<hr />
+
 	<h2 id="table">
 		Table
 	</h2>

--- a/src/pages/design-tokens/component/light.astro
+++ b/src/pages/design-tokens/component/light.astro
@@ -276,6 +276,24 @@ const description = 'Component specific tokens to be used only when rebuilding c
 
 			<hr />
 
+			<h2 id="push-button">
+				Push Button
+			</h2>
+			{
+				component('light', 'push-button').map((token) => (
+					<RuxDesignTokenPreview
+    client:load
+						name={token.name}
+						value={token.value}
+						alias={token.referenceToken}
+						description={token.description}
+						type={lookupProperty(token.category, token.property)}
+					/>
+				))
+			}
+
+			<hr />
+
 
 			<h2 id="radio">
 				Radio
@@ -381,6 +399,23 @@ const description = 'Component specific tokens to be used only when rebuilding c
 				))
 			}
 
+			<hr />
+
+			<h2 id="tab">
+				Tab
+			</h2>
+			{
+				component('light', 'tab').map((token) => (
+					<RuxDesignTokenPreview
+						client:load
+						name={token.name}
+						value={token.value}
+						alias={token.referenceToken}
+						description={token.description}
+						type={lookupProperty(token.category, token.property)}
+					/>
+				))
+			}
 			<hr />
 
 			<h2 id="table">

--- a/src/pages/design-tokens/system/index.astro
+++ b/src/pages/design-tokens/system/index.astro
@@ -43,7 +43,9 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<h2 id="border">Border Colors</h2>
 	{
-		system('dark', 'color', 'border').map((token) => (
+		system('dark', 'color', 'border')
+		.filter((token) => !token.name.includes('focus'))
+		.map((token) => (
 			<RuxDesignTokenPreview
 				client:load
 				name={token.name}

--- a/src/pages/design-tokens/system/index.astro
+++ b/src/pages/design-tokens/system/index.astro
@@ -121,7 +121,21 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<hr />
 
-	<h2 id="border-width">Focus Border Width</h2>
+	<h2 id="Focus">Focus</h2>
+	{
+		system('dark', 'color', 'border')
+			.filter((token) => token.name.includes('focus'))
+			.map((token) => (
+				<RuxDesignTokenPreview
+					client:load
+					name={token.name}
+					value={token.value}
+					alias={token.referenceToken}
+					description={token.description}
+					type="border"
+				/>
+			))
+	}
 	{
 		system('dark', 'borderWidth', 'focus').map((token) => (
 			<RuxDesignTokenPreview
@@ -134,10 +148,6 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			/>
 		))
 	}
-
-	<hr />
-
-	<h2 id="spacing">Focus Spacing</h2>
 	{
 		system('dark', 'spacing', 'focus').map((token) => (
 			<RuxDesignTokenPreview
@@ -168,6 +178,5 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	}
 
 	<hr />
-
 </DocsLayout>
 <script></script>

--- a/src/pages/design-tokens/system/index.astro
+++ b/src/pages/design-tokens/system/index.astro
@@ -7,14 +7,13 @@ import { RuxDesignTokenPreview } from '@astrouxds/documentation-components'
 const title = 'System Tokens'
 const description = 'Tokens representing Astro semantic design decisions.'
 ---
+
 <DocsLayout content={{ title, description }} file={import.meta.url}>
-	<h2 id="background">
-		Background Colors
-	</h2>
+	<h2 id="background">Background Colors</h2>
 	{
 		system('dark', 'color', 'background').map((token) => (
 			<RuxDesignTokenPreview
-    client:load
+				client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -26,13 +25,11 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<hr />
 
-	<h2 id="text">
-		Text Colors
-	</h2>
+	<h2 id="text">Text Colors</h2>
 	{
 		system('dark', 'color', 'text').map((token) => (
 			<RuxDesignTokenPreview
-    client:load
+				client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -44,13 +41,11 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<hr />
 
-	<h2 id="border">
-		Border Colors
-	</h2>
+	<h2 id="border">Border Colors</h2>
 	{
 		system('dark', 'color', 'border').map((token) => (
 			<RuxDesignTokenPreview
-    client:load
+				client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -62,13 +57,11 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<hr />
 
-	<h2 id="status">
-		Status Colors
-	</h2>
+	<h2 id="status">Status Colors</h2>
 	{
 		system('dark', 'color', 'status').map((token) => (
 			<RuxDesignTokenPreview
-    client:load
+				client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -80,13 +73,11 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<hr />
 
-	<h2 id="classification">
-		Classification Colors
-	</h2>
+	<h2 id="classification">Classification Colors</h2>
 	{
 		system('dark', 'color', 'classification').map((token) => (
 			<RuxDesignTokenPreview
-    client:load
+				client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -95,13 +86,30 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			/>
 		))
 	}
-	<h2 id="data-viz">
-		Data Visualization
-	</h2>
+
+	<hr />
+
+	<h2 id="opacity">Opacity</h2>
+	{
+		system('dark', 'opacity', 'disabled').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="opacity"
+			/>
+		))
+	}
+
+	<hr />
+
+	<h2 id="data-viz">Data Visualization</h2>
 	{
 		system('dark', 'color', 'data-visualization').map((token) => (
 			<RuxDesignTokenPreview
-    client:load
+				client:load
 				name={token.name}
 				value={token.value}
 				alias={token.referenceToken}
@@ -110,6 +118,56 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			/>
 		))
 	}
+
+	<hr />
+
+	<h2 id="border-width">Focus Border Width</h2>
+	{
+		system('dark', 'borderWidth', 'focus').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="border-width"
+			/>
+		))
+	}
+
+	<hr />
+
+	<h2 id="spacing">Focus Spacing</h2>
+	{
+		system('dark', 'spacing', 'focus').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="spacing"
+			/>
+		))
+	}
+
+	<hr />
+
+	<h2 id="shadow">Shadow Overlay</h2>
+	{
+		system('dark', 'boxShadow', undefined).map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="opacity"
+			/>
+		))
+	}
+
+	<hr />
+
 </DocsLayout>
-<script>
-</script>
+<script></script>

--- a/src/pages/design-tokens/system/light.astro
+++ b/src/pages/design-tokens/system/light.astro
@@ -43,7 +43,9 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<h2 id="border">Border Colors</h2>
 	{
-		system('light', 'color', 'border').map((token) => (
+		system('light', 'color', 'border')
+		.filter((token) => !token.name.includes('focus'))
+		.map((token) => (
 			<RuxDesignTokenPreview
 				client:load
 				name={token.name}
@@ -121,7 +123,21 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<hr />
 
-	<h2 id="border-width">Focus Border Width</h2>
+	<h2 id="Focus">Focus</h2>
+	{
+		system('light', 'color', 'border')
+			.filter((token) => token.name.includes('focus'))
+			.map((token) => (
+				<RuxDesignTokenPreview
+					client:load
+					name={token.name}
+					value={token.value}
+					alias={token.referenceToken}
+					description={token.description}
+					type="border"
+				/>
+			))
+	}
 	{
 		system('light', 'borderWidth', 'focus').map((token) => (
 			<RuxDesignTokenPreview
@@ -134,10 +150,6 @@ const description = 'Tokens representing Astro semantic design decisions.'
 			/>
 		))
 	}
-
-	<hr />
-
-	<h2 id="spacing">Focus Spacing</h2>
 	{
 		system('light', 'spacing', 'focus').map((token) => (
 			<RuxDesignTokenPreview

--- a/src/pages/design-tokens/system/light.astro
+++ b/src/pages/design-tokens/system/light.astro
@@ -7,108 +7,166 @@ import { RuxDesignTokenPreview } from '@astrouxds/documentation-components'
 const title = 'System Tokens'
 const description = 'Tokens representing Astro semantic design decisions.'
 ---
+
 <DocsLayout content={{ title, description }} file={import.meta.url}>
-			<h2 id="background">
-				Background Colors
-			</h2>
-			{
-				system('light', 'color', 'background').map((token) => (
-					<RuxDesignTokenPreview
-    client:load
-						name={token.name}
-						value={token.value}
-						alias={token.referenceToken}
-						description={token.description}
-						type="background"
-					/>
-				))
-			}
+	<h2 id="background">Background Colors</h2>
+	{
+		system('light', 'color', 'background').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="background"
+			/>
+		))
+	}
 
-			<hr />
+	<hr />
 
-			<h2 id="text-colors">
-				Text Colors
-			</h2>
-			{
-				system('light', 'color', 'text').map((token) => (
-					<RuxDesignTokenPreview
-    client:load
-						name={token.name}
-						value={token.value}
-						alias={token.referenceToken}
-						description={token.description}
-						type="text"
-					/>
-				))
-			}
+	<h2 id="text-colors">Text Colors</h2>
+	{
+		system('light', 'color', 'text').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="text"
+			/>
+		))
+	}
 
-			<hr />
+	<hr />
 
-			<h2 id="border">
-				Border Colors
-			</h2>
-			{
-				system('light', 'color', 'border').map((token) => (
-					<RuxDesignTokenPreview
-    client:load
-						name={token.name}
-						value={token.value}
-						alias={token.referenceToken}
-						description={token.description}
-						type="border"
-					/>
-				))
-			}
+	<h2 id="border">Border Colors</h2>
+	{
+		system('light', 'color', 'border').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="border"
+			/>
+		))
+	}
 
-			<hr />
+	<hr />
 
-			<h2 id="status">
-				Status Colors
-			</h2>
-			{
-				system('light', 'color', 'status').map((token) => (
-					<RuxDesignTokenPreview
-    client:load
-						name={token.name}
-						value={token.value}
-						alias={token.referenceToken}
-						description={token.description}
-						type="background"
-					/>
-				))
-			}
+	<h2 id="status">Status Colors</h2>
+	{
+		system('light', 'color', 'status').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="background"
+			/>
+		))
+	}
 
-			<hr />
+	<hr />
 
-			<h2 id="classification">
-				Classification Colors
-			</h2>
-			{
-				system('light', 'color', 'classification').map((token) => (
-					<RuxDesignTokenPreview
-    client:load
-						name={token.name}
-						value={token.value}
-						alias={token.referenceToken}
-						description={token.description}
-						type="background"
-					/>
-				))
-			}
+	<h2 id="classification">Classification Colors</h2>
+	{
+		system('light', 'color', 'classification').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="background"
+			/>
+		))
+	}
 
-		<h2 id="data-viz">
-			Data Visualization
-		</h2>
-		{
-			system('light', 'color', 'data-visualization').map((token) => (
-				<RuxDesignTokenPreview
-    client:load
-					name={token.name}
-					value={token.value}
-					alias={token.referenceToken}
-					description={token.description}
-					type="background"
-				/>
-			))
-		}
+	<hr />
+
+	<h2 id="opacity">Opacity</h2>
+	{
+		system('light', 'opacity', 'disabled').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="opacity"
+			/>
+		))
+	}
+
+	<hr />
+
+	<h2 id="data-viz">Data Visualization</h2>
+	{
+		system('light', 'color', 'data-visualization').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="background"
+			/>
+		))
+	}
+
+	<hr />
+
+	<h2 id="border-width">Focus Border Width</h2>
+	{
+		system('light', 'borderWidth', 'focus').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="border-width"
+			/>
+		))
+	}
+
+	<hr />
+
+	<h2 id="spacing">Focus Spacing</h2>
+	{
+		system('light', 'spacing', 'focus').map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="spacing"
+			/>
+		))
+	}
+
+	<hr />
+
+
+	<h2 id="shadow">Shadow Overlay</h2>
+	{
+		system('light', 'boxShadow', undefined).map((token) => (
+			<RuxDesignTokenPreview
+				client:load
+				name={token.name}
+				value={token.value}
+				alias={token.referenceToken}
+				description={token.description}
+				type="opacity"
+			/>
+		))
+	}
+
+	<hr />
 </DocsLayout>

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -30,7 +30,7 @@ export const component = (theme: string, componentName: string) => {
 	return themeTokens.filter((token) => token.component === componentName)
 }
 
-export const system = (theme: string, category: string, property: string) => {
+export const system = (theme: string, category: string, property: string | undefined) => {
 	let themeTokens = tokens
 
 	if (theme === 'light') {


### PR DESCRIPTION
There were a handful of missing tokens on the system and component pages. The following have now been added to the light and dark sections of each page:

**Component**
- Push Button
- Tab

**System**
- Opacity
- Focus Border Width
- Shadow Overlay
- Focus Spacing