### PR TITLE
fix(case studies): broken links on case studies pages

### DIFF
--- a/src/pages/case-studies/fd-service-ux-design/about-the-fd-designs.md
+++ b/src/pages/case-studies/fd-service-ux-design/about-the-fd-designs.md
@@ -105,7 +105,7 @@ For operators of the FDS Application, flexibility and automating redundant tasks
 
 ### Global Status Bar
 
-The [Global Status Bar](../../components/global-status-bar) of the FDS App contains a single sign in, high level navigation [tabs](../../components/tabs) to switch between tools, a [clock](../../components/clock) and notification, chat and help icons. [Monitoring icons](../../components/icons-and-symbols) may be included if the mission requires additional situational awareness.
+The [Global Status Bar](/components/global-status-bar/) of the FDS App contains a single sign in, high level navigation [tabs](/components/tabs/) to switch between tools, a [clock](/components/clock/) and notification, chat and help icons. [Monitoring icons](/components/icons-and-symbols/) may be included if the mission requires additional situational awareness.
 
 ![Global Status Bar](/img/service-specific-ux-design/fds/fds-global-status-bar.webp)
 

--- a/src/pages/case-studies/grm-service-ux-design/about-the-grm-designs.md
+++ b/src/pages/case-studies/grm-service-ux-design/about-the-grm-designs.md
@@ -53,7 +53,7 @@ The GRM App Suite comprises three integrated sample apps: Dashboard, Equipment M
 
 The GRM Dashboard app rolls up all information necessary for providing operators the highest level of situational awareness.
 
-- [Overview of GRM Dashboard](/grm-service-ux-design/grm-dashboard/)
+- [Overview of GRM Dashboard](/case-studies/grm-service-ux-design/grm-dashboard/)
 - [Launch GRM Dashboard Sample App](https://grm-dashboard-react.netlify.app)
 - <button data-app="GRM" type="button" class="p-source-code-dialog-open">Request Source Code Access</button>
 
@@ -68,7 +68,7 @@ The GRM Dashboard app rolls up all information necessary for providing operators
 
 The GRM Equipment Manager app consolidates all ground equipment in one place, allowing operators to view status and request maintenance.
 
-- [Overview of GRM Equipment Manager](/grm-service-ux-design/grm-equipment-manager/)
+- [Overview of GRM Equipment Manager](/case-studies/grm-service-ux-design/grm-equipment-manager/)
 - [Launch GRM Equipment Manager Sample App](https://grm-equipment-react-ts.netlify.app)
 - <button data-app="GRM" type="button" class="p-source-code-dialog-open">Request Source Code Access</button>
 
@@ -83,7 +83,7 @@ The GRM Equipment Manager app consolidates all ground equipment in one place, al
 
 The GRM Schedule app allows operators to view and manage the full schedule of contacts in their sphere of responsibility.
 
-- [Overview of GRM Schedule](/grm-service-ux-design/grm-schedule/)
+- [Overview of GRM Schedule](/case-studies/grm-service-ux-design/grm-schedule/)
 - [Launch GRM Schedule Sample App](https://grm-schedule-react.netlify.app)
 - <button data-app="GRM" type="button" class="p-source-code-dialog-open">Request Source Code Access</button>
 

--- a/src/pages/case-studies/grm-service-ux-design/grm-dashboard.md
+++ b/src/pages/case-studies/grm-service-ux-design/grm-dashboard.md
@@ -7,7 +7,7 @@ title: GRM Dashboard
 description: Helps operators maintain situational awareness.
 ---
 
-[Launch GRM Dashboard Sample App](https://grm-dashboard-react.netlify.app) | [Design Materials and Source Code](/grm-service-ux-design/grm-dashboard/#design-materials-and-source-code)
+[Launch GRM Dashboard Sample App](https://grm-dashboard-react.netlify.app) | [Design Materials and Source Code](/case-studies/grm-service-ux-design/grm-dashboard/#design-materials-and-source-code)
 
 Given the large number of satellite contacts and equipment assets that operators are responsible for, maintaining situational awareness poses a significant challenge. Operators must be able to quickly identify equipment issues and resolve them so that there are no missed opportunities to communicate with satellites. The GRM Dashboard app was designed with this goal in mind. As an operator's primary GRM app, it would constantly occupy one of their large displays.
 
@@ -19,7 +19,7 @@ There are three main areas of the GRM Dashboard app: the Global Status Bar, the 
 
 ## Global Status Bar
 
-As outlined on the [About GRM Designs](/grm-service-ux-design/about-the-grm-designs) page, each of the apps in the GRM Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar), an Astro component featured in all three apps. Status bars contain an App Switcher Menu, that allows operators to transition quickly from one GRM task flow to another, a [Clock](/components/clock), and [Monitoring Icons](/components/icons-and-symbols). Status bar contents may vary somewhat between apps in order to best support each app’s individual workflows.
+As outlined on the [About GRM Designs](/case-studies/grm-service-ux-design/about-the-grm-designs/) page, each of the apps in the GRM Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar/), an Astro component featured in all three apps. Status bars contain an App Switcher Menu, that allows operators to transition quickly from one GRM task flow to another, a [Clock](/components/clock/), and [Monitoring Icons](/components/icons-and-symbols/). Status bar contents may vary somewhat between apps in order to best support each app’s individual workflows.
 
 ![GRM Dashboard App Details](/img/case-studies/grm/grm-dashboard-global-status-bar-details.webp)
 
@@ -64,7 +64,7 @@ The Equipment tab provides operators with a usage summary of the major equipment
 
 ## Alert Details
 
-If operators choose to expand an alert via the Investigate button in the Alerts panel, an Alert Details page is displayed in the main content area. The content of the page changes somewhat depending on whether the alert pertains to a contact or a piece of equipment, but each variant allows operators to view additional detail on the alert, dismiss, acknowledge it, or take some action to remedy it. The image below shows an example of the Alert Details page for a contact-related alert; you can find information on the equipment variant along with relevant task flows in the [GRM Design Specifications](/grm-service-ux-design/grm-dashboard/#design-materials-and-source-code) and Wireframes documents.
+If operators choose to expand an alert via the Investigate button in the Alerts panel, an Alert Details page is displayed in the main content area. The content of the page changes somewhat depending on whether the alert pertains to a contact or a piece of equipment, but each variant allows operators to view additional detail on the alert, dismiss, acknowledge it, or take some action to remedy it. The image below shows an example of the Alert Details page for a contact-related alert; you can find information on the equipment variant along with relevant task flows in the [GRM Design Specifications](/case-studies/grm-service-ux-design/grm-dashboard/#design-materials-and-source-code) and Wireframes documents.
 
 ![GRM Dashboard Alert Details](/img/case-studies/grm/grm-dashboard-alerts-details.webp)
 
@@ -78,7 +78,7 @@ If operators choose to expand an alert via the Investigate button in the Alerts 
 
 ## Contact Details
 
-If operators choose to click a specific contact within the Current Contacts table, a Contact Details page is displayed in the main content area. The content of the page allows operators to view additional detail on the contact and take action to modify it if necessary. The image below shows an example of the Contact Details page; you can find additional information with relevant task flows in the [GRM Design Specifications](/grm-service-ux-design/grm-dashboard/#design-materials-and-source-code) and Wireframes documents.
+If operators choose to click a specific contact within the Current Contacts table, a Contact Details page is displayed in the main content area. The content of the page allows operators to view additional detail on the contact and take action to modify it if necessary. The image below shows an example of the Contact Details page; you can find additional information with relevant task flows in the [GRM Design Specifications](/case-studies/grm-service-ux-design/grm-dashboard/#design-materials-and-source-code) and Wireframes documents.
 
 ![GRM Dashboard Contact Details](/img/case-studies/grm/grm-dashboard-contact-details.webp)
 
@@ -96,8 +96,6 @@ Below is an animated walkthrough of a representative task flow using the GRM Das
  <figure>
   <a href="#demo" class="demo" name="close">
    <span class="icon-play"></span>
-   <img src="/img/case-studies/grm/grm-dashboard-modify-string-placeholder.png"
-   alt="GRM Dashboard demo" />
   </a>
  </figure>
  <a href="#close" class="lightbox" id="demo" markdown="1">

--- a/src/pages/case-studies/grm-service-ux-design/grm-equipment-manager.md
+++ b/src/pages/case-studies/grm-service-ux-design/grm-equipment-manager.md
@@ -7,7 +7,7 @@ title: GRM Equipment Manager
 description: The GRM Equipment Manager app is designed for operators by consolidating information related to all ground equipment in one place.
 ---
 
-[Launch GRM Equipment Manager Sample App](https://grm-equipment-react-ts.netlify.app) | [Design Materials and Source Code](/grm-service-ux-design/grm-equipment-manager/#design-materials-and-source-code)
+[Launch GRM Equipment Manager Sample App](https://grm-equipment-react-ts.netlify.app) | [Design Materials and Source Code](/case-studies/grm-service-ux-design/grm-equipment-manager/#design-materials-and-source-code)
 
 A core requirement of GRM is to ensure that the equipment on the ground responsible for communicating with satellites is operational and available. This equipment includes hardware such as antennas, processors and software systems that all must interact with one another during a satellite contact. These resources are often shared amongst multiple operations, so if a piece of equipment is not available, it can affect multiple missions. As such, it is critical for operators to quickly identify equipment in need of attention and schedule maintenance to get it back up and running as quickly as possible.
 
@@ -21,7 +21,7 @@ There are three main areas of the GRM Equipment Manager app: the Global Status B
 
 ## Global Status Bar
 
-As outlined on the [About GRM Designs](/grm-service-ux-design/about-the-grm-designs) page, each of the apps in the GRM Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar), an Astro component featured in all three apps. Status bars contain an App Switcher Menu, that allows operators to transition quickly from one GRM task flow to another, a [Clock](/components/clock), and [Monitoring Icons](/components/icons-and-symbols). Status bar contents may vary somewhat between apps in order to best support each app’s individual workflows.
+As outlined on the [About GRM Designs](/case-studies/grm-service-ux-design/about-the-grm-designs/) page, each of the apps in the GRM Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar/), an Astro component featured in all three apps. Status bars contain an App Switcher Menu, that allows operators to transition quickly from one GRM task flow to another, a [Clock](/components/clock/), and [Monitoring Icons](/components/icons-and-symbols/). Status bar contents may vary somewhat between apps in order to best support each app’s individual workflows.
 
 ![GRM Dashboard App Details](/img/case-studies/grm/grm-equipment-manager-global-status-bar-details.webp)
 
@@ -31,7 +31,7 @@ As outlined on the [About GRM Designs](/grm-service-ux-design/about-the-grm-desi
 
 ## Equipment Navigation Tree
 
-Along the left side of the GRM Equipment Manager app is a [navigation tree](/components/tree) that organizes the equipment in hierarchical form. The nature of the hierarchy would likely vary based on the structure of the operation, so it would need to be configurable on a per deployment basis. Using the tree, operators could drill in through the hierarchy and select a piece of equipment. Once the equipment is selected, a new tab is added in the tabbed content area and its details are displayed.
+Along the left side of the GRM Equipment Manager app is a [navigation tree](/components/tree/) that organizes the equipment in hierarchical form. The nature of the hierarchy would likely vary based on the structure of the operation, so it would need to be configurable on a per deployment basis. Using the tree, operators could drill in through the hierarchy and select a piece of equipment. Once the equipment is selected, a new tab is added in the tabbed content area and its details are displayed.
 
 ![GRM Equipment Manager Navigation Tree](/img/case-studies/grm/grm-equipment-manager-nav-tree-details.webp)
 
@@ -74,7 +74,7 @@ There are two panels on the Equipment Details page, one on top designed to provi
 
 A key capability of the Maintenance panel is that it allows operators to schedule a new job. When Schedule Job is clicked, Maintenance Details appear and operators can enter all required information. Once a time frame for the job has been entered, clicking the Calculate Conflicts button will display any schedule conflicts that will arise when this equipment is unavailable during the maintenance window. Seeing this information allows operators to either schedule the maintenance to minimize impact or to see the contacts that will have to be modified to use a different piece of equipment during that period.
 
-Note that maintenance-related task flows are covered in much more detail in the [GRM Design Specification and Wireframes](/grm-service-ux-design/grm-equipment-manager/#design-materials-and-source-code) documents, so be sure to consult those for more information.
+Note that maintenance-related task flows are covered in much more detail in the [GRM Design Specification and Wireframes](/case-studies/grm-service-ux-design/grm-equipment-manager/#design-materials-and-source-code) documents, so be sure to consult those for more information.
 
 ![GRM Equipment Manager Schedule Jobs Details](/img/case-studies/grm/grm-equipment-manager-sched-maint-details.webp)
 

--- a/src/pages/case-studies/grm-service-ux-design/grm-schedule.md
+++ b/src/pages/case-studies/grm-service-ux-design/grm-schedule.md
@@ -7,7 +7,7 @@ title: GRM Schedule
 description: The GRM Schedule app allows operators to view and interact with the full schedule of contacts via a Timeline or List View.
 ---
 
-[Launch GRM Schedule Sample App](https://grm-schedule-react.netlify.app) | [Design Materials and Source Code](/grm-service-ux-design/grm-schedule/#design-materials-and-source-code)
+[Launch GRM Schedule Sample App](https://grm-schedule-react.netlify.app) | [Design Materials and Source Code](/case-studies/grm-service-ux-design/grm-schedule/#design-materials-and-source-code)
 
 Ground Resource Management (GRM) operations require ensuring that all the necessary equipment is available during the time windows when a target satellite is in range. Complicating this task is the fact that there are multiple simultaneous satellite contacts to manage, pieces of equipment that are shared amongst operational groups, and shifting priorities that can require a well-orchestrated schedule to be modified in-flight. Operators need to be able to monitor these impacts to the schedule and make the necessary modifications quickly to ensure that satellite operations can continue.
 
@@ -21,7 +21,7 @@ There are three main areas in the Schedule app: the Global Status Bar, the Conta
 
 ## Global Status Bar
 
-As outlined on the [About GRM Designs](/grm-service-ux-design/about-the-grm-designs) page, each of the apps in the GRM Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar), an Astro component featured in all three apps. Status bars contain an App Switcher Menu, that allows operators to transition quickly from one GRM task flow to another, a [Clock](/components/clock), and [Monitoring Icons](/components/icons-and-symbols).
+As outlined on the [About GRM Designs](/case-studies/grm-service-ux-design/about-the-grm-designs/) page, each of the apps in the GRM Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar/), an Astro component featured in all three apps. Status bars contain an App Switcher Menu, that allows operators to transition quickly from one GRM task flow to another, a [Clock](/components/clock/), and [Monitoring Icons](/components/icons-and-symbols/).
 
 ![GRM Schedule Global Status Bar Details](/img/case-studies/grm/grm-schedule-global-status-bar-details.webp)
 
@@ -35,7 +35,7 @@ The GRM Schedule app presents operators with two alternative views of their cont
 
 ### Timeline View
 
-In the [Timeline](/components/timeline) view, contacts are plotted by ground station and antenna on the y-axis and time on the x-axis. The contacts are represented as bars, the length of which indicates the duration of the contact. This design, which is based on the Astro Timeline component, provides operators with a consolidated view of the time and status for all recent, current and future contacts in their system. To allow operators to focus in on particular elements of interest, Ground Station rows can be expanded to show individual antennas, the timeline can be filtered by contact status, or zoomed in/out to focus on a particular time range.
+In the [Timeline](/components/timeline/) view, contacts are plotted by ground station and antenna on the y-axis and time on the x-axis. The contacts are represented as bars, the length of which indicates the duration of the contact. This design, which is based on the Astro Timeline component, provides operators with a consolidated view of the time and status for all recent, current and future contacts in their system. To allow operators to focus in on particular elements of interest, Ground Station rows can be expanded to show individual antennas, the timeline can be filtered by contact status, or zoomed in/out to focus on a particular time range.
 
 ![GRM Schedule Timeline View](/img/case-studies/grm/grm-schedule-timeline-details.webp)
 
@@ -60,9 +60,9 @@ The List view shares many of the elements of the Timeline view including the tim
 
 ## Manage Contacts Pane
 
-Operators can view additional detail on a contact by clicking on it in the timeline or row in the list view. This detail is presented in a [Modeless Pane](/patterns/modeless-panes) that draws in from the right side of the window so operators aren’t taken away from the main app view. The data in the pane is presented in read-only form initially, but a Modify Contact button swaps the read-only view for an editable one, allowing operators to change the contact’s settings. Similarly, to schedule a new contact, operators can click on the Add Contact button which opens the pane to specify settings.
+Operators can view additional detail on a contact by clicking on it in the timeline or row in the list view. This detail is presented in a [Modeless Pane](/patterns/modeless-panes/) that draws in from the right side of the window so operators aren’t taken away from the main app view. The data in the pane is presented in read-only form initially, but a Modify Contact button swaps the read-only view for an editable one, allowing operators to change the contact’s settings. Similarly, to schedule a new contact, operators can click on the Add Contact button which opens the pane to specify settings.
 
-The image below shows the Contact pane for this Add Contact task flow. To see the view contact and modify contact variants of the pane, and more design and task flow details, download the [GRM Design Specification or Wireframes](/grm-service-ux-design/grm-schedule/#design-materials-and-source-code). You can also interact with these elements in the [GRM Schedule Sample App](https://grm-schedule-react.netlify.app).
+The image below shows the Contact pane for this Add Contact task flow. To see the view contact and modify contact variants of the pane, and more design and task flow details, download the [GRM Design Specification or Wireframes](/case-studies/grm-service-ux-design/grm-schedule/#design-materials-and-source-code). You can also interact with these elements in the [GRM Schedule Sample App](https://grm-schedule-react.netlify.app).
 
 :::two-col
 ![GRM Schedule Manage Contacts Pane](/img/case-studies/grm/grm-schedule-manage-contacts-details.webp)

--- a/src/pages/case-studies/service-specific-ux-design.md
+++ b/src/pages/case-studies/service-specific-ux-design.md
@@ -6,11 +6,11 @@ layout: project:layouts/docs/docs-layout.astro
 
 The Service Specific UX Design effort supported Space Systems Command (SSC) to develop consistent, robust applications. The design efforts achieved the goal by applying UX Design processes aligned with the Astro Space UX Design System to create, document, and implement baseline designs as interactive sample apps. The work described here focused on two key services, [Ground Resource Management (GRM)][grm-designs] and [Telemetry, Tracking & Command (TT&C)][ttc-designs] and followed the process below:
 
-- Conducted [UX research](/design-process/research) with users and stakeholders to identify key task flows, constraints, and current pain points in existing systems.
-- Used the findings from this research and the Astro Space UX Design System to [design](/design-process/ui-design) solutions to support GRM and TT&C Services.
+- Conducted [UX research](/resources/research/) with users and stakeholders to identify key task flows, constraints, and current pain points in existing systems.
+- Used the findings from this research and the Astro Space UX Design System to [design](/resources/ui-design/) solutions to support GRM and TT&C Services.
 - In partnership with users and stakeholders, iteratively evaluated and improved on the designs to ensure they support the key task flows in an efficient and usable manner.
-- Implemented the resulting designs as interactive sample applications using the [Astro UI Components](/components/readme).
-- Provided the detailed design specifications, wireframes, sample applications, and source code as [downloadable resources](/downloads) to teams looking to develop applications supporting GRM and TT&C Services.
+- Implemented the resulting designs as interactive sample applications using the [Astro UI Components](/components/getting-started/).
+- Provided the detailed design specifications, wireframes, sample applications, and source code as [downloadable resources](/resources/downloads/) to teams looking to develop applications supporting GRM and TT&C Services.
 
 Design efforts included several hours of user and stakeholder interviews, detailed task flow analysis, and iterative design evaluations based on user feedback. The result of the design activities produced sample app designs to reference for developing future GRM and TT&C apps, fostering consistent and functional user experience across systems.
 
@@ -51,11 +51,11 @@ The [TT&C Investigate][ttc-investigate] app allows the operator to investigate s
 You can get an overview of the design work on the [About the TT&C Designs][ttc-designs] page or use one of the links below to get more information about a particular app.
 ![](/img/case-studies/service-specific-ux-design/ttc-investigate-app.webp)
 
-[grm-designs]: /grm-service-ux-design/about-the-grm-designs
-[grm-dashboard]: /grm-service-ux-design/grm-dashboard
-[grm-equipment]: /grm-service-ux-design/grm-equipment-manager
-[grm-schedule]: /grm-service-ux-design/grm-schedule
-[ttc-designs]: /ttc-service-ux-design/about-the-ttc-designs
-[ttc-monitor]: /ttc-service-ux-design/ttc-monitor
-[ttc-command]: /ttc-service-ux-design/ttc-command
-[ttc-investigate]: /ttc-service-ux-design/ttc-investigate
+[grm-designs]: /case-studies/grm-service-ux-design/about-the-grm-designs/
+[grm-dashboard]: /case-studies/grm-service-ux-design/grm-dashboard/
+[grm-equipment]: /case-studies/grm-service-ux-design/grm-equipment-manager/
+[grm-schedule]: /case-studies/grm-service-ux-design/grm-schedule/
+[ttc-designs]: /case-studies/ttc-service-ux-design/about-the-ttc-designs/
+[ttc-monitor]: /case-studies/ttc-service-ux-design/ttc-monitor/
+[ttc-command]: /case-studies/ttc-service-ux-design/ttc-command/
+[ttc-investigate]: /case-studies/ttc-service-ux-design/ttc-investigate/

--- a/src/pages/case-studies/ttc-service-ux-design/about-the-ttc-designs.md
+++ b/src/pages/case-studies/ttc-service-ux-design/about-the-ttc-designs.md
@@ -56,7 +56,7 @@ The TT&C App Suite comprises three integrated apps: Monitor, Command, & Investig
 :::col
 The TT&C Monitor app allows operators to monitor status, alerts, health, and function of an individual satellite and satellite constellations.
 
-- [Overview of TT&C Monitor](/ttc-service-ux-design/ttc-monitor)
+- [Overview of TT&C Monitor](/case-studies/ttc-service-ux-design/ttc-monitor/)
 - [Launch TT&C Monitor Sample App](https://monitor-ttc.netlify.app)
 - <button data-app="TT&C" type="button" class="p-source-code-dialog-open">Request Source Code Access</button>
   :::
@@ -70,7 +70,7 @@ The TT&C Monitor app allows operators to monitor status, alerts, health, and fun
 :::col
 The TT&C Command app allows operators to send and receive streams of data to and from a spacecraft using a set of commands, often referred to as a pass plan.
 
-- [Overview of TT&C Command](/ttc-service-ux-design/ttc-command)
+- [Overview of TT&C Command](/case-studies/ttc-service-ux-design/ttc-command/)
 - [Launch TT&C Command Sample App](https://ttc-command-react.netlify.app/)
 - <button data-app="TT&C" type="button" class="p-source-code-dialog-open">Request Source Code Access</button>
 
@@ -85,7 +85,7 @@ The TT&C Command app allows operators to send and receive streams of data to and
 :::col
 The TT&C Investigate App allows operators to investigate spacecraft alerts and anomalies and analyze subsystem mnemonics, measurements, limits, etc.
 
-- [Overview of TT&C Investigate](/ttc-service-ux-design/ttc-investigate)
+- [Overview of TT&C Investigate](/case-studies/ttc-service-ux-design/ttc-investigate/)
 - [Launch TT&C Investigate Sample App](https://ttc-command-react.netlify.app)
 - <button data-app="TT&C" type="button" class="p-source-code-dialog-open">Request Source Code Access</button>
   :::

--- a/src/pages/case-studies/ttc-service-ux-design/ttc-command.md
+++ b/src/pages/case-studies/ttc-service-ux-design/ttc-command.md
@@ -7,7 +7,7 @@ title: TT&C Command
 description: The TT&C Command App is designed to be used for sending and receiving communications with a satellite during a contact.
 ---
 
-[Launch TT&C Command Sample App](https://ttc-command-react.netlify.app/) | [Design Materials and Source Code](/ttc-service-ux-design/ttc-command/#design-materials-and-source-code)
+[Launch TT&C Command Sample App](https://ttc-command-react.netlify.app/) | [Design Materials and Source Code](/case-studies/ttc-service-ux-design/ttc-command/#design-materials-and-source-code)
 
 The TT&C Command App is designed to be used for sending and receiving communications with a satellite during a contact. It contains status and command data for only a single satellite - one currently in a pass. Operators can open multiple command windows if they are managing several passes simultaneously.
 
@@ -17,13 +17,13 @@ Another aspect of the design aimed at reducing cognitive load is to give operato
 
 ![TT&C Command App](/img/case-studies/tt&c/ttc-command-app.webp)
 
-There are four main areas in the Command App: the Global Status Bar, Alerts panel, Pass Plan panel, and System Health panel. The key elements are described below, but you can find much more design and task flow detail in the [TT&C Design Specification and Wireframes](/ttc-service-ux-design/ttc-command/#design-materials-and-source-code) documents. You can also launch the [TT&C Command Sample App](https://ttc-command-react.netlify.app/) to explore the design interactively.
+There are four main areas in the Command App: the Global Status Bar, Alerts panel, Pass Plan panel, and System Health panel. The key elements are described below, but you can find much more design and task flow detail in the [TT&C Design Specification and Wireframes](/case-studies/ttc-service-ux-design/ttc-command/#design-materials-and-source-code) documents. You can also launch the [TT&C Command Sample App](https://ttc-command-react.netlify.app/) to explore the design interactively.
 
 ![TT&C Command App Details](/img/case-studies/tt&c/ttc-command-app-details.webp)
 
 ## Global Status Bar
 
-As outlined on the [About TT&C Designs](/ttc-service-ux-design/about-the-ttc-designs) page, each of the apps in the TT&C Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar), an Astro component featured in all three apps. Though the status bar contents vary somewhat between apps in order to best support each app’s individual workflows, all contain a [Clock](/components/clock), [Monitoring Icons](/components/icons-and-symbols), and an App Switcher Menu that allows operators to transition quickly from one TT&C task flow to another.
+As outlined on the [About TT&C Designs](/case-studies/ttc-service-ux-design/about-the-ttc-designs/) page, each of the apps in the TT&C Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar/), an Astro component featured in all three apps. Though the status bar contents vary somewhat between apps in order to best support each app’s individual workflows, all contain a [Clock](/components/clock/), [Monitoring Icons](/components/icons-and-symbols/), and an App Switcher Menu that allows operators to transition quickly from one TT&C task flow to another.
 
 ![TT&C Command Global Status Bar Details](/img/case-studies/tt&c/ttc-command-global-status-bar-details.webp)
 
@@ -33,7 +33,7 @@ As outlined on the [About TT&C Designs](/ttc-service-ux-design/about-the-ttc-des
 
 ## Alerts
 
-The Alerts panel provides operators with a roll-up of spacecraft specific alerts, as well as communications, software, and its assigned ground station. Operators can filter the alerts by Severity and Category, allowing them to quickly identify the most severe issues or focus in on particular areas of the system. This allows operators to efficiently track their workflow and keeps the Alerts pane more sparsely populated, so they will be more likely to notice when new alerts come in. Operators can also drill in to see additional information on any of the alerts and launch an instance of the [TT&C Investigate App](/ttc-service-ux-design/ttc-investigate) to explore the issue further.
+The Alerts panel provides operators with a roll-up of spacecraft specific alerts, as well as communications, software, and its assigned ground station. Operators can filter the alerts by Severity and Category, allowing them to quickly identify the most severe issues or focus in on particular areas of the system. This allows operators to efficiently track their workflow and keeps the Alerts pane more sparsely populated, so they will be more likely to notice when new alerts come in. Operators can also drill in to see additional information on any of the alerts and launch an instance of the [TT&C Investigate App](/case-studies/ttc-service-ux-design/ttc-investigate/) to explore the issue further.
 
 :::two-col
 ![TT&C Command Alerts Detail](/img/case-studies/tt&c/ttc-monitor-alerts-details.webp)
@@ -81,8 +81,6 @@ Below is an animated walkthrough of a representative task flow using the TT&C Co
  <figure markdown="1" >
   <a href="#demo" class="demo" name="close">
    <span class="icon-play"></span>
-   <img src="/img/case-studies/tt&c/ttc-command-execute-pass-plan-placeholder.png"
-   alt="TT&C Command Execute Pass Plan demo" />
   </a>
  </figure>
  <a href="#close" class="lightbox" id="demo">

--- a/src/pages/case-studies/ttc-service-ux-design/ttc-investigate.md
+++ b/src/pages/case-studies/ttc-service-ux-design/ttc-investigate.md
@@ -7,7 +7,7 @@ title: TT&C Investigate
 description: The Investigate App displays system schematics and status data for a selected satellite.
 ---
 
-[Launch TT&C Investigate Sample App](https://ttc-command-react.netlify.app/) | [Design Materials and Source Code](/ttc-service-ux-design/ttc-investigate/#design-materials-and-source-code)
+[Launch TT&C Investigate Sample App](https://ttc-command-react.netlify.app/) | [Design Materials and Source Code](/case-studies/ttc-service-ux-design/ttc-investigate/#design-materials-and-source-code)
 
 The Investigate App displays system schematics and status data for a selected satellite. This allows operators to gather additional detail on alerts, view the relationships of components in the equipment hierarchy, and select particular values to add to the Watcher panel in the Monitor and Command Apps.
 
@@ -15,13 +15,13 @@ UX research revealed that existing systems often require operators to drill-in t
 
 ![TT&C Investigate App](/img/case-studies/tt&c/ttc-investigate-app.webp)
 
-There are four main areas in the Investigate App: the Global Status Bar, Subsystem Tree Menu, Subsystem Assembly Layout, and Mnemonic Data Table. The key elements are described below, but you can find much more design and task flow detail in the [TT&C Design Specification and Wireframes](/ttc-service-ux-design/ttc-investigate/#design-materials-and-source-code) documents. You can also launch the [TT&C Investigate Sample App](https://ttc-command-react.netlify.app) to explore the design interactively.
+There are four main areas in the Investigate App: the Global Status Bar, Subsystem Tree Menu, Subsystem Assembly Layout, and Mnemonic Data Table. The key elements are described below, but you can find much more design and task flow detail in the [TT&C Design Specification and Wireframes](/case-studies/ttc-service-ux-design/ttc-investigate/#design-materials-and-source-code) documents. You can also launch the [TT&C Investigate Sample App](https://ttc-command-react.netlify.app) to explore the design interactively.
 
 ![TT&C Investigate App Details](/img/case-studies/tt&c/ttc-investigate-app-details.webp)
 
 ## Global Status Bar
 
-As outlined on the [About TT&C Designs](/ttc-service-ux-design/about-the-ttc-designs) page, each of the apps in the TT&C Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar), an Astro component featured in all three apps. Though the status bar contents vary somewhat between apps in order to best support each app’s individual workflows, all contain a [Clock](/components/clock), [Monitoring Icons](/components/icons-and-symbols), and an App Switcher Menu that allows operators to transition quickly from one TT&C task flow to another.
+As outlined on the [About TT&C Designs](/case-studies/ttc-service-ux-design/about-the-ttc-designs/) page, each of the apps in the TT&C Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar/), an Astro component featured in all three apps. Though the status bar contents vary somewhat between apps in order to best support each app’s individual workflows, all contain a [Clock](/components/clock/), [Monitoring Icons](/components/icons-and-symbols/), and an App Switcher Menu that allows operators to transition quickly from one TT&C task flow to another.
 
 ![TT&C Dashboard Global Status Bar Details](/img/case-studies/tt&c/ttc-investigate-global-status-bar-details.webp)
 
@@ -69,8 +69,6 @@ Below is an animated walkthrough of a representative task flow using the TT&C In
  <figure markdown="1">
   <a href="#demo" class="demo" name="close">
    <span class="icon-play"></span>
-   <img src="/img/case-studies/tt&c/ttc-investigate-add-watcher-placeholder.png"
-   alt="TT&C Investigate Add Watcher demo" />
   </a>
  </figure>
  <a href="#close" class="lightbox" id="demo">

--- a/src/pages/case-studies/ttc-service-ux-design/ttc-monitor.md
+++ b/src/pages/case-studies/ttc-service-ux-design/ttc-monitor.md
@@ -7,7 +7,7 @@ title: TT&C Monitor
 description: The TT&C Monitor app monitors system and constellation health, upcoming contacts and system trends.
 ---
 
-[Launch TT&C Monitor Sample App](https://monitor-ttc.netlify.app) | [Design Materials and Source Code](/ttc-service-ux-design/ttc-monitor/#design-materials-and-source-code)
+[Launch TT&C Monitor Sample App](https://monitor-ttc.netlify.app) | [Design Materials and Source Code](/case-studies/ttc-service-ux-design/ttc-monitor/#design-materials-and-source-code)
 
 For operators of a TT&C service, maintaining situational awareness is of critical importance, and the TT&C Monitor App is designed to support this requirement. During the UX research effort, operators expressed a desire for a quick and efficient way to view overall status of their constellation and all of their systems, something lacking in their current systems. To deliver on this, the design team worked with domain experts and the operators to identify the most important data and then display it in a clear, logical manner in the app.
 
@@ -15,13 +15,13 @@ The Monitor App, as an operator’s primary TT&C App, would constantly occupy on
 
 ![TT&C Monitor App](/img/case-studies/tt&c/ttc-monitor-app.webp)
 
-There are four main areas in the Monitor App: the Global Status Bar, Alerts panel, Constellation panel, and Watcher panel. The key elements are described below, but you can find much more design and task flow detail in the [TT&C Design Specification and Wireframes](/ttc-service-ux-design/ttc-monitor/#design-materials-and-source-code) documents. You can also launch the [TT&C Monitor Sample App](https://monitor-ttc.netlify.app) to explore the design interactively.
+There are four main areas in the Monitor App: the Global Status Bar, Alerts panel, Constellation panel, and Watcher panel. The key elements are described below, but you can find much more design and task flow detail in the [TT&C Design Specification and Wireframes](/case-studies/ttc-service-ux-design/ttc-monitor/#design-materials-and-source-code) documents. You can also launch the [TT&C Monitor Sample App](https://monitor-ttc.netlify.app) to explore the design interactively.
 
 ![TT&C Monitor App Details](/img/case-studies/tt&c/ttc-monitor-app-details.webp)
 
 ## Global Status Bar
 
-As outlined on the [About TT&C Designs](/ttc-service-ux-design/about-the-ttc-designs) page, each of the apps in the TT&C Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar), an Astro component featured in all three apps. Though the status bar contents vary somewhat between apps in order to best support each app’s individual workflows, all contain a [Clock](/components/clock), [Monitoring Icons](/components/icons-and-symbols), and an App Switcher Menu that allows operators to transition quickly from one TT&C task flow to another.
+As outlined on the [About TT&C Designs](/case-studies/ttc-service-ux-design/about-the-ttc-designs/) page, each of the apps in the TT&C Suite is designed to occupy its own browser window, allowing operators to focus on the task at hand. But by virtue of being integrated into a suite, the apps share common functionality, such as a single login. Much of the shared functionality is provided in the [Global Status Bar](/components/global-status-bar/), an Astro component featured in all three apps. Though the status bar contents vary somewhat between apps in order to best support each app’s individual workflows, all contain a [Clock](/components/clock/), [Monitoring Icons](/components/icons-and-symbols/), and an App Switcher Menu that allows operators to transition quickly from one TT&C task flow to another.
 
 ![TT&C Monitor App Details](/img/case-studies/tt&c/ttc-monitor-global-status-bar-details.webp)
 
@@ -45,7 +45,7 @@ The Alerts panel provides operators with a roll-up of alerts across the ground s
 
 ## Constellation
 
-The Constellation panel shows the contacts for the satellites in the constellation. The operator has the option to either view these in a Timeline View, which shows past, current, and future contacts along a scalable time range, or in a List View, which provides additional detail on each pass. In both views, the user can click a contact to open a [Modeless Pane](/patterns/modeless-panes) containing its Contact Details or the associated Pass Plan.
+The Constellation panel shows the contacts for the satellites in the constellation. The operator has the option to either view these in a Timeline View, which shows past, current, and future contacts along a scalable time range, or in a List View, which provides additional detail on each pass. In both views, the user can click a contact to open a [Modeless Pane](/patterns/modeless-panes/) containing its Contact Details or the associated Pass Plan.
 
 ### Timeline View
 


### PR DESCRIPTION
The case studies pages for the demo apps for re-ordered in the code so the directory structure matched the actual page navigation. There were links in these pages that were not updated to match this new structure. They all work now.