### PR TITLE
Fix: Update index.astro EGS to Astro Compliance

### DIFF
--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -69,7 +69,7 @@ const description = `Astro represents a collection of artifacts including, but n
 					<td><a href="https://github.com/RocketCommunicationsInc/astro/releases/tag/v7.25.1">Release Notes</a></td>
 				</tr>
 				<tr>
-					<td>EGS Design Compliance</td>
+					<td>Astro Design Compliance</td>
 					<td class="tabular">4.2.0</td>
 					<td></td>
 				</tr>


### PR DESCRIPTION
I was on the Releases page and saw that the compliance was still listed as EGS compliance instead of Astro compliance, so I'm trying to make that word change on the Releases page.