### PR TITLE
Reference dashboard products

### DIFF
--- a/netlify/functions/stripe.js
+++ b/netlify/functions/stripe.js
@@ -1,4 +1,10 @@
-// STRIPE_SECRET for real
+/**
+ * Stripe Checkout Function
+ * This Netlify serverless function creates Stripe checkout sessions for
+ * digital product purchases with automatic tax calculation.
+ */
+
+// Initialize Stripe using the sandbox secret key from environment variables
 const stripe = require('stripe')(process.env.STRIPE_SANDBOX_SECRET)
 // const baseUrl = process.env.DEPLOY_URL || process.env.BASE_URL || 'http://localhost:8888'
 const baseUrl = process.env.BASE_URL
@@ -12,25 +18,28 @@ const baseUrl = process.env.BASE_URL
 // 	baseUrl = 'https://www.astrouxds.com'
 // }
 
+/**
+ * Product catalog with Stripe-specific IDs
+ * Each product contains:
+ * - stripeProductId: ID of the product in Stripe dashboard
+ * - stripePriceId: ID of the price object in Stripe dashboard
+ * - name: Display name of the product
+ */
 const PRODUCTS = {
-	// 'fds': {
-	// 	name: 'FDS Source Code',
-	// 	unit_amount: 10000 // Amount in cents (i.e., $100.00)
-	// },
-	// 'grm': {
-	// 	name: 'GRM Source Code',
-	// 	unit_amount: 10000
-	// },
-	// 'ttc': {
-	// 	name: 'TT&C Source Code',
-	// 	unit_amount: 10000
-	// },
   'astro-toolkit-ppt': {
     stripeProductId: 'prod_SLdY3pRKOo37hn',
     stripePriceId: 'price_1RQwHUCX2F0Knv6wHJ8f615k',
     name: 'Astro Toolkit PPT'
   }
   }
+
+  /**
+ * Main function handler for the Netlify serverless function
+ * Creates a Stripe checkout session based on selected products
+ *
+ * @param {Object} event - The Netlify function event object
+ * @returns {Object} Response with session ID or error message
+ */
   exports.handler = async (event) => {
 	try {
 		// Parse the incoming request body
@@ -61,28 +70,21 @@ const PRODUCTS = {
 		mode: 'payment',
 		success_url: `${baseUrl}/checkout/success/?session_id={CHECKOUT_SESSION_ID}`,
 		cancel_url: `${baseUrl}/platforms/astro-toolkit-ppt/`,
+		// Enable automatic tax calculation based on customer location
 		automatic_tax: {
          enabled: true
         },
+		// Collect billing address for tax calculation
         billing_address_collection: 'required',
-		// custom_fields: [
-		// 	{
-		// 	key: 'engraving',
-		// 	label: {
-		// 		type: 'custom',
-		// 		custom: 'Personalized engraving',
-		// 	},
-		// 	type: 'text',
-		// 	optional: true,
-		// 	},
-		// ],
 	})
 
+	// Return successful response with session ID
 	return {
 		statusCode: 200,
 		body: JSON.stringify({ id: session.id }),
 	}
 	} catch (error) {
+	// Log and return error if checkout session creation fails
 	console.error('Error creating checkout session:', error)
 	return {
 		statusCode: 500,

--- a/netlify/functions/stripe.js
+++ b/netlify/functions/stripe.js
@@ -30,7 +30,7 @@ const PRODUCTS = {
     stripeProductId: 'prod_SLdY3pRKOo37hn',
     stripePriceId: 'price_1RQwHUCX2F0Knv6wHJ8f615k',
     name: 'Astro Toolkit PPT'
-  }
+}
   }
 
   /**
@@ -57,7 +57,10 @@ const PRODUCTS = {
 	// eslint-disable-next-line camelcase
 	const line_items = selectedProducts.map(productCode => {
       const product = PRODUCTS[productCode]
-      return {
+		if (!product) {
+			throw new Error(`Invalid product code: ${productCode}`)
+		}
+    return {
         price: product.stripePriceId,
         quantity: 1,
       }

--- a/netlify/functions/stripe.js
+++ b/netlify/functions/stripe.js
@@ -25,10 +25,11 @@ const PRODUCTS = {
 	// 	name: 'TT&C Source Code',
 	// 	unit_amount: 10000
 	// },
-	'astro-toolkit-ppt': {
-		name: 'Astro Toolkit PPT',
-		unit_amount: 4900
-	}
+  'astro-toolkit-ppt': {
+    stripeProductId: 'prod_SLdY3pRKOo37hn',
+    stripePriceId: 'price_1RQwHUCX2F0Knv6wHJ8f615k',
+    name: 'Astro Toolkit PPT'
+  }
   }
   exports.handler = async (event) => {
 	try {
@@ -46,18 +47,12 @@ const PRODUCTS = {
 	// Create line items based on the selected products
 	// eslint-disable-next-line camelcase
 	const line_items = selectedProducts.map(productCode => {
-		const product = PRODUCTS[productCode]
-		return {
-		price_data: {
-			currency: 'usd',
-			product_data: {
-				name: product.name,
-			},
-			unit_amount: product.unit_amount,
-		},
-			quantity: 1, // You can make this dynamic if needed
-		}
-	})
+      const product = PRODUCTS[productCode]
+      return {
+        price: product.stripePriceId,
+        quantity: 1,
+      }
+    })
 	// Create the Stripe checkout session
 	const session = await stripe.checkout.sessions.create({
 		payment_method_types: [ 'card' ],
@@ -66,6 +61,10 @@ const PRODUCTS = {
 		mode: 'payment',
 		success_url: `${baseUrl}/checkout/success/?session_id={CHECKOUT_SESSION_ID}`,
 		cancel_url: `${baseUrl}/platforms/astro-toolkit-ppt/`,
+		automatic_tax: {
+         enabled: true
+        },
+        billing_address_collection: 'required',
 		// custom_fields: [
 		// 	{
 		// 	key: 'engraving',


### PR DESCRIPTION
What we are doing: 

This changes how products are managed with Stripe. Previously we were sending a product definition object from the front end to Stripe. 

Now we define the product in the Stripe [Dashboard.](https://dashboard.stripe.com/test/products?active=true) 

Why?: 

This has several benefits.
- Allows the persistence of the item being purchased in the Stripe Dashboard. (previously the item object created and "archived" item that was only findable from the transaction and not in the products section of the Stripe Dashboard
- It allows us to set an expected tax code on the product enabling us to take advantage of the Stripe tax features. (ie. taxes will be collected if the area for the address entered is registered with Stripe by accounting.
- Price changes and tax collection can be managed by subject matter experts rather than developers

Possible improvements:
- The Product and Price IDs are hard coded into the file. If for some reason a product is deleted and re-created this will break. It would be nice to be able to have human readable unique product names agreed upon by the organization to always exist and then programmatically pull the IDs thus preventing product changes in Stripe from breaking things. 

Testing Guidance:
I have a review app of the Go API running here:
https://dashboard.heroku.com/apps/astrouxds-ap-dev-enviro-qbexve/settings
Stripe Sandbox product is here
https://dashboard.stripe.com/test/products/prod_SLdY3pRKOo37hn
Local Dev instructions is here
https://rocketcom.atlassian.net/wiki/spaces/AS11/pages/3611525123/AstroUXDS-WWW+Astro+API+-+Local+Development+Setup