### PR TITLE
chore: update release version for astro web components

### DIFF
--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -23,7 +23,7 @@ const description = `Astro represents a collection of artifacts including, but n
 				<tr>
 					<th colspan="3">
 						Astro { globalData.designSystem.version } - Updated
-						<time>March, 4 2025</time>
+						<time>May, 21 2025</time>
 					</th>
 				</tr>
 			</thead>
@@ -36,7 +36,7 @@ const description = `Astro represents a collection of artifacts including, but n
 				<tr>
 					<td>Design Tokens</td>
 					<td class="tabular">1.14.0</td>
-					<td><a href="https://github.com/RocketCommunicationsInc/astro-design-tokens/releases/tag/v1.12.0">Release Notes</a></td>
+					<td><a href="https://github.com/RocketCommunicationsInc/astro-design-tokens/releases/tag/v1.14.0">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Dark Theme Library</td>
@@ -65,8 +65,8 @@ const description = `Astro represents a collection of artifacts including, but n
 				</tr>
 				<tr>
 					<td>Web Components</td>
-					<td class="tabular">7.25.0 -&gt; <b>7.25.1</b></td>
-					<td><a href="https://github.com/RocketCommunicationsInc/astro/releases/tag/v7.25.1">Release Notes</a></td>
+					<td class="tabular">7.25.1 -&gt; <b>7.25.2</b></td>
+					<td><a href="https://github.com/RocketCommunicationsInc/astro/releases/tag/v7.25.2">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Astro Design Compliance</td>


### PR DESCRIPTION
Updates the version of astro-web-components to 7.25.2. 
Fixes astro-tokens version pointing to wrong release. 