### PR TITLE
show the power point kit banner on the home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ import signup from 'project:data/home-signup.json'
 <Layout>
 	<Version />
 	<Banner {...banner.data} />
-	<!-- <ProductBanner /> -->
+	<ProductBanner />
 	<Explainer data={explainer.data} />
 	<Community data={community.data} />
 	<Articles data={articles.data} />


### PR DESCRIPTION
We are just uncommenting the Power Point Kit advert banner. This was left out of the initial merge so we could do some testing before showing this big banner. 