### PR TITLE
fix empty shadow overlay section

### DIFF
--- a/src/pages/design-tokens/system/index.astro
+++ b/src/pages/design-tokens/system/index.astro
@@ -167,7 +167,7 @@ const description = 'Tokens representing Astro semantic design decisions.'
 
 	<h2 id="shadow">Shadow Overlay</h2>
 	{
-		system('dark', 'boxShadow', undefined).map((token) => (
+		system('dark', 'boxShadow', 'overlay').map((token) => (
 			<RuxDesignTokenPreview
 				client:load
 				name={token.name}

--- a/src/pages/design-tokens/system/light.astro
+++ b/src/pages/design-tokens/system/light.astro
@@ -166,9 +166,8 @@ const description = 'Tokens representing Astro semantic design decisions.'
 	<hr />
 
 
-	<h2 id="shadow">Shadow Overlay</h2>
-	{
-		system('light', 'boxShadow', undefined).map((token) => (
+	<h2 id="shadow">Shadow Overlay</h2>	{
+		system('light', 'boxShadow', 'overlay').map((token) => (
 			<RuxDesignTokenPreview
 				client:load
 				name={token.name}


### PR DESCRIPTION
https://rocketcom.atlassian.net/jira/software/projects/AP/boards/119?assignee=712020%3A6a79a1e3-7381-4656-9516-c09792ad18be%2C60e2c268bd7f5d006886d1bf&selectedIssue=AP-495

There is a lot of info on the card above.

There were three reasons that the box shadow area was empty.
Property Filter: the system function is filtering tokens where token.property === property, but for boxShadow tokens, we pass undefined which won't match the actual properties like "overlay" or "inner".

System/Theme Level: the system function only returns tokens where tokenLevel === 'system' || tokenLevel === 'theme', but the boxShadow tokens in docs.json mostly have tokenLevel === 'component'.

Component Null: our filter requires token.component === null, but most boxShadow tokens have a specific component like "card" or "scrollbar".

Looking closer at the data and making the assumption that the logic in the `system` function located in `tokens.ts` is accurate then we are most concerned with the `property: 'overlay'` box shadow entry. I think this is correct for two reasons: first the title of the section is `Shadow Overlay` and all the other box shadow entries have there `tokenLevel` property set to `component` which is excluded from presentation based on the logic in the `system` function. 