### PR TITLE
Update classification-markings.md with Dec 2019 rule updates

### DIFF
--- a/src/pages/components/classification-markings.md
+++ b/src/pages/components/classification-markings.md
@@ -30,6 +30,7 @@ This page lists general guidance and components for marking practices. For the m
 
 - [CUI Registry](https://www.archives.gov/cui): Latest standards for CUI from the NARA
 - [CUI Blog](https://isoo.blogs.archives.gov/): Latest updates for CUI including previews of upcoming policy changes
+- [DOD CUI Program](https://www.dodcui.mil/): DOD-specific CUI Guidelines
 
 The guidance on this page is focused on the use of, and rules for, Classification and Control Markings in electronic application designs for government clients. Information about markings for emails, presentations, or other media (e.g. printed documents) can be found in the [Additional Resources](#additional-resources) linked at the end of the page.
 
@@ -41,7 +42,7 @@ The guidance on this page is focused on the use of, and rules for, Classificatio
 |                                                                                                                 | State            | Hex Value | RGB Value    | CSS                                                     | Font Color |
 |-----------------------------------------------------------------------------------------------------------------|------------------|-----------|--------------|---------------------------------------------------------|------------|
 | ![Marking Unclassified Swatch](/img/components/classification-markings/swatches/marking__unclassified.svg)      | Unclassified     | #007a33   | 0, 122, 51   | `--classification-banner-color-background-unclassified` | white      |
-| ![Marking Controlled Swatch](/img/components/classification-markings/swatches/marking__controlled.svg)          | Controlled (CUI) | #502b85   | 80, 43, 133  | `--classification-banner-color-background-cui`          | white      |
+| ![Marking Controlled Swatch](/img/components/classification-markings/swatches/marking__controlled.svg)          | CUI              | #502b85   | 80, 43, 133  | `--classification-banner-color-background-cui`          | white      |
 | ![Marking Confidential Swatch](/img/components/classification-markings/swatches/marking__confidential.svg)      | Confidential     | #0033a0   | 0, 51, 160   | `--classification-banner-color-background-confidential` | white      |
 | ![Marking Secret Swatch](/img/components/classification-markings/swatches/marking__secret.svg)                  | Secret           | #c8102e   | 200, 16, 46  | `--classification-banner-color-background-secret`       | white      |
 | ![Marking Top Secret Swatch](/img/components/classification-markings/swatches/marking__top-secret.svg)          | Top Secret       | #ff8c00   | 255, 140, 0  | `--classification-banner-color-background-topsecret`    | black      |
@@ -54,15 +55,15 @@ Applications used on government workstations with access to classified networks 
 
 ### Overall Marking Text
 
-Text in the Overall Marking Banner should be as specific as possible to the highest level of classified information contained in that system or view. The banner message should follow the standard marking structure (placeholder text example: CLASSIFICATION// SCI// SAP// AEA// FGI// CUI// DISSEM) with bold, centered text in all capital letters. The classification level itself (excepting CUI) must be spelled out completely (example: UNCLASSIFIED instead of just U), but later caveats or Control Markings in the classification text can be abbreviated in their traditional formats or spelled out completely (example: SP-EXPT or SP-EXPORT CONTROLLED). CUI level marking banners can use CUI or the word CONTROLLED as the classification text. Only classification and/or control information in the standard format should be present in this banner. Supplemental administrative markings such as Draft should not be commingled into the Overall Marking Banner.
+Text in the Overall Marking Banners should be as specific as possible to the highest level of classified information contained in that system or view. The banner messages should follow the standard marking structure (placeholder text example: CLASSIFICATION LEVEL//SAFEGUARDING-ACCESS REQUIREMENTS//DISTRIBUTION REQUIREMENTS) with bold, centered text in all capital letters. The classification level itself (excepting CUI) must be spelled out completely (example: UNCLASSIFIED instead of just U), but later caveats or Control Markings in the classification text can be abbreviated in their traditional formats or spelled out completely (example: TOP SECRET//SPECIAL ACCESS REQUIRED-PROGRAM NICKNAME or TOP SECRET//SAR-PROGRAM NICKNAME). As of December 2024, CUI documents must use CUI as the text in the banner line, not CONTROLLED or CONTROLLED UNCLASSIFIED INFORMATION. CUI markings should not include any category information in the banner line. Those are saved for the Designation Indicator. Only classification and/or control information in the standard format should be present in this banner. Supplemental administrative markings such as Draft should not be commingled into the Overall Marking Banner.
 
 ### Overall Marking Placement
 
-Place an Overall Marking Banner at the top and bottom of the application in a fixed position so that they cannot scroll out of view. Since the banner message can be quite long, we recommend that the banner span the full width of the application. This mimics physical classification markings, which span the full width of the document page. Note that a top banner is mandatory, but it is best practice to include an identical Overall Marking Banner at the bottom of the viewport as well.
+Place an Overall Marking Banner at the top and bottom of the application in a fixed position so that they cannot scroll out of view. Since the banner message can be quite long, we recommend that the banner span the full width of the application. This mimics physical classification markings, which span the full width of the document page. Note that a top banner is mandatory, but it is best practice to include an identical Overall Marking Banner at the bottom of the viewport as well. If you are not including a bottom banner, make sure that the top banner is visible at all times.
 
 ### Overall Marking Colors
 
-Astro banner component colors match what government users are familiar with in physical labels, their workstations, and other applications. Adding a colored background is not officially required by the government, but is culturally expected and does help with recognizing classification levels at a quick glance. Similarly, there are no particular color values required by the ISOO for specific classification levels for digital markings. The background colors for the banner components are based on the traditional Pantone colors used in the relevant Standard Form labels for SF 706 through SF 712 with the new addition of the purple CUI color from SF-902. The text colors for the banners are either white or black (the two text colors used on the physical labels) depending on which best contrasts with the background color. There is, however, a risk that the classification colors could create confusion when compared with similar colors used for status purposes, so the visual footprint of the banner has been reduced in Astro to the smallest recommended height.
+Astro banner component colors match what government users are familiar with in physical labels, their workstations, and other applications. Adding a colored background is NOT required by the government, but does help with recognizing classification levels at a quick glance. Similarly, there are no particular color values required by the ISOO for specific classification levels for digital markings. The background colors for the Astro banner components are based on the traditional Pantone colors used in the relevant Standard Form labels for SF 706 through SF 712 with the new addition of the purple CUI color from SF-902. The text colors for the banners are either white or black (the two text colors used on the physical labels) depending on which best contrasts with the background color. There is, however, a risk that the classification colors could create confusion when compared with similar colors used for status purposes, so the visual footprint of the banner has been reduced in Astro to the smallest recommended height.
 
 ## Examples
 
@@ -76,9 +77,9 @@ Astro banner component colors match what government users are familiar with in p
 
 ![Don’t: Allow the banner to scroll out of view or be obscured by other elements](/img/components/classification-markings/overall-marking-dont-2.webp "Don’t: Allow the banner to scroll out of view or be obscured by other elements")
 
-![Do: Use Astro’s defined color sets for contrast compliance ](/img/components/classification-markings/overall-marking-do-3.webp "Do: Use Astro’s defined color sets for contrast compliance")
+![Do: Use Astro’s defined color sets for contrast compliance and familiarity](/img/components/classification-markings/overall-marking-do-3.webp "Do: Use Astro’s defined color sets for contrast compliance and familiarity")
 
-![Don’t: Deviate from the defined background colors](/img/components/classification-markings/overall-marking-dont-3.webp "Don’t: Deviate from the defined background colors")
+![Don’t: Use background colors in ways that actively conflict with standard practices and meanings](/img/components/classification-markings/overall-marking-dont-3.webp "Don’t: Use background colors in ways that actively conflict with standard practices and meanings")
 
 :::
 
@@ -94,13 +95,15 @@ Proper Portion Marking is critical to reduce classification problems and leaks. 
 
 For those developing applications/websites, there are specific rules about Portion Marking file names, URLs, and metadata. To learn more about these aspects, review the requirements in the relevant [Additional Resources](#additional-resources).
 
-Current policies require Portion Marking throughout a document, but, in practice, Portion Marking is often left to section markings at best. At a minimum, include section markings using the standard abbreviated text format in parentheses or other enclosed format, such as a Tag, if the classification information is available. Give serious consideration to adding Portion Marking to individual fields with drastically different classification levels or to move higher classification items to a separate section if the new grouping is still consistent with the user’s mental model and the UI organization. If relevant, the information could also be portrayed in a separate, labeled column in a table for each item’s row (preferably in an immediately visible location). In this case, the parentheses should no longer be necessary as the column division should provide enough differentiation from the rest of the table text and the column label clarifies the type of content.
+Current policies require Portion Marking throughout a document, but, in practice, Portion Marking is often left to section markings at best in dynamic space applications. At a minimum, include section markings using the standard abbreviated text format in parentheses or other enclosed format, such as a Tag, if the classification information is available. Give serious consideration to adding Portion Marking to individual fields with drastically different classification levels or to move higher classification items to a separate section if the new grouping is still consistent with the user’s mental model and the UI organization. If relevant, the information could also be portrayed in a separate, labeled column in a table for each item’s row (preferably in an immediately visible location). In this case, the parentheses should no longer be necessary as the column division should provide enough differentiation from the rest of the table text and the column label clarifies the type of content.
 
-There are few exceptions to Portion Marking requirements, but the ISOO does acknowledge that different types of documents such as “dynamic documents,” a category that many applications or databases fall under, may have difficulty with these requirements. If a document is not portion marked fully and the classification/control level is higher than CUI, the responsible agency for the application may need to obtain a waiver from the ISOO and will need to indicate on the document that it cannot be used as a derivative source document.
+There are few exceptions to Portion Marking requirements, but the ISOO does acknowledge that different types of documents such as “dynamic documents,” a category that many applications or databases fall under, may have difficulty with these requirements. If a document is not portion marked fully and the classification/control level is higher than CUI, the responsible agency for the application may need to obtain a waiver from the ISOO and will need to indicate on the document that it cannot be used as a derivative source document. In this case, another line of text should be included in the UI with words along the lines of:
+
+> This content is classified at [highest overall classification] level and may contain elements of information that are unclassified or classified at a lower level than the classification displayed. This content shall not be used as a source of derivative classification.
 
 ### Portion Marking Text
 
-Portion Markings should be bold, all capital letters and abbreviated within parentheses like (CUI//SP-EXPT) or within a Tag as seen in the components pictured above. They can also be spelled out in full, if needed, however this method should be avoided for longer text strings. Note that control markings such as SCI, SAP, AEA, CUI, or dissemination are also required in Portion Markings if they are relevant to that portion.
+Portion Markings should be bold, all capital letters and abbreviated within parentheses like (TS//SAR-PN) or within a Tag as seen in the components pictured above. Note that control markings such as SCI, SAP, AEA, or dissemination are also required in Portion Markings if they are relevant to that portion.
 
 ### Portion Marking Placement
 
@@ -110,7 +113,7 @@ Portion Markings should be placed at the top or top-left of the classified or co
 
 ### Portion Marking Colors
 
-The colors used in the Tag components are the same as those in the Overall Banner Markings for easy recognition.
+The colors used in the Tag components are the same as those in the Overall Banner Markings for easy recognition. These colors are NOT required by the government, but can assist with easier recognition of classification or control level.
 
 ## Examples
 
@@ -134,13 +137,14 @@ The colors used in the Tag components are the same as those in the Overall Banne
 
 ### Authority Block Guidelines
 
-Whenever classified or controlled information is present, use an Authority Block, to trace the source of the designation and any necessary clarifications about declassification dates or classification reasons. The Authority Block is typically in the bottom left of a document page, but can be placed elsewhere according to layout needs. Similarly, if necessary in the layout, the authority information for electronic material may appear as a single line of text instead of the typical three-line approach. Note that there is a slightly different structure for CUI, originally classified documents, and documents with a classification derived from another document. Authority Blocks are most often displayed as lines of text and do not currently require a component to satisfy this marking requirement. To learn more about this element, go to our [Additional Resources](#additional-resources).
+Whenever classified or controlled information is present, use a Classification Authority Block (CAB) or Designation Indicator (DI) for CUI, to trace the source of the designation and any necessary clarifications about declassification dates or classification reasons. The Authority Block is typically in the bottom left of the first page of a document, but can be placed elsewhere within the area bracketed by the banner lines (such as at the top of a scrolling spreadsheet) according to layout needs. When both classified information and CUI are present on the same page, both a CAB and DI is necessary. Traditionally, the CAB and DI appear in the same row in a document with the CAB on the left and the DI on the right side of the page. If necessary in the layout, the authority information for electronic material may appear as a single line of text instead of the typical three-line approach. Note that there is a slightly different structure for CUI, originally classified documents, and documents with a classification derived from another document. Authority Blocks are most often displayed as lines or blocks of text and do not currently require a component to satisfy this marking requirement. To learn more about this element, go to our [Additional Resources](#additional-resources).
 
 :::table-overflow
 | **Do**                                                                                                           |
 |------------------------------------------------------------------------------------------------------------------|
 | Show the source of classified or controlled information on a page with relevant contact information.             |
 | Clarify if the classified information is originally classified or derivatively classified from another document. |
+| Include both a CAB and a DI if both CUI and classified information are present.                                  |
 ::::
 
 ## Additional Resources
@@ -162,3 +166,4 @@ Whenever classified or controlled information is present, use an Authority Block
   - [CUI Marking Handbook V1.1 (6 December 2016)](https://www.archives.gov/files/cui/documents/20161206-cui-marking-handbook-v1-1-20190524.pdf)
   - [CUI Coversheet and Labels: SF 901, 902, 903](https://isoo.blogs.archives.gov/2019/02/12/coversheets/)
 - [CUI Blog](https://isoo.blogs.archives.gov/): Latest updates for CUI including previews of upcoming policy changes
+- [DOD CUI Program](https://www.dodcui.mil/): DOD-specific CUI Guidelines


### PR DESCRIPTION
- Added new DOD CUI link to the Additional Resources section.
- Removed typo of spaces between slashes in overall marking text example
- Updated examples of banner text to be more clear
- Removed the inclusion of CUI markings in banners with classified information
- Changed CUI banner guidance to remove the option of CONTROLLED text and the option of including category information in the banner.
- Changed wording about colors to emphasize that they are NOT required by the government
- Clarified that top banner should be sticky if there's no bottom banner
- Added more information about CAB and DI and their interactions
- Added more information about dynamic documents
- Removed information about using long version of names in portion marking