### PR TITLE
docs: Update index.astro with latest Figma version numbers

### DIFF
--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -23,7 +23,7 @@ const description = `Astro represents a collection of artifacts including, but n
 				<tr>
 					<th colspan="3">
 						Astro { globalData.designSystem.version } - Updated
-						<time>May, 21 2025</time>
+						<time>July 25, 2025</time>
 					</th>
 				</tr>
 			</thead>
@@ -40,17 +40,17 @@ const description = `Astro represents a collection of artifacts including, but n
 				</tr>
 				<tr>
 					<td>Figma Dark Theme Library</td>
-					<td class="tabular">7.8.3</td>
+					<td class="tabular">8.0.0</td>
 					<td><a href="https://www.figma.com/community/file/1157371532469023309">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Light Theme Library</td>
-					<td class="tabular">7.6.2</td>
+					<td class="tabular">8.0.0</td>
 					<td><a href="https://www.figma.com/community/file/1203068683334364243">Release Notes</a></td>
 				</tr>
 				<tr>
 					<td>Figma Wireframe Theme Library</td>
-					<td class="tabular">7.6.2</td>
+					<td class="tabular">8.0.0</td>
 					<td><a href="https://www.figma.com/community/file/1203487593021750781">Release Notes</a></td>
 				</tr>
 				<tr>


### PR DESCRIPTION
Updated Figma file version numbers to reflect change to 8.0.0 for all three Astro 7 files to account for the breaking change updates to Date Picker.