### PR TITLE
docs: roll back figma icon library version number

### DIFF
--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -60,7 +60,7 @@ const description = `Astro represents a collection of artifacts including, but n
 				</tr>
 				<tr>
 					<td>Figma Icon Library for Astro 6 & 7</td>
-					<td class="tabular">2.0.0</td>
+					<td class="tabular">1.1.0</td>
 					<td></td>
 				</tr>
 				<tr>


### PR DESCRIPTION
Returned version number for Figma icon library from 2.0.0 to 1.1.0 since we rolled back the breaking change.

https://rocketcom.atlassian.net/browse/AP-642